### PR TITLE
fix(tests): isolate Lightning log dirs to fix parallel test race

### DIFF
--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -331,7 +331,9 @@ def _make_neural_forecaster(cls, **extra_kwargs):
         "max_steps": 5,
         # Use a unique temp directory so parallel xdist workers don't race on
         # the shared ``lightning_logs/version_N`` directory.
-        "trainer_kwargs": {"default_root_dir": tempfile.mkdtemp()},
+        # neuralforecast forwards unknown kwargs straight to pl.Trainer, so
+        # ``default_root_dir`` is passed at the top level, not nested.
+        "default_root_dir": tempfile.mkdtemp(),
     }
     # Per-model architecture reduction for faster tests.
     _model_defaults = {

--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -8,6 +8,8 @@ Covers ``BaseNeuralForecaster`` and concrete wrapper classes:
 
 from __future__ import annotations
 
+import tempfile
+
 import polars as pl
 import pytest
 from sklearn.base import clone
@@ -324,7 +326,13 @@ class TestFitPredict:
 
 def _make_neural_forecaster(cls, **extra_kwargs):
     """Create a neural forecaster with sensible defaults for fast testing."""
-    defaults = {"input_size": 12, "max_steps": 5}
+    defaults = {
+        "input_size": 12,
+        "max_steps": 5,
+        # Use a unique temp directory so parallel xdist workers don't race on
+        # the shared ``lightning_logs/version_N`` directory.
+        "trainer_kwargs": {"default_root_dir": tempfile.mkdtemp()},
+    }
     # Per-model architecture reduction for faster tests.
     _model_defaults = {
         "MLPForecaster": {"hidden_size": 8, "num_layers": 1},


### PR DESCRIPTION
## Description

Fixes a `FileExistsError` in the nightly CI caused by parallel pytest-xdist workers racing to create `lightning_logs/version_N` directories when all tests share the same working directory.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The `test_coverage` nox session runs tests with `-n auto` (xdist parallel workers). Multiple slow neural tests called `NeuralForecast.fit()` concurrently while sharing the same CWD, so Lightning's auto-incrementing `version_N` directory was created by two workers simultaneously:

```
FAILED tests/test_neural.py::TestFitValidation::test_convert_nixtla_to_yohou_legacy
FileExistsError: [Errno 17] File exists: '.../lightning_logs/version_4'
```

`_make_neural_forecaster` now injects `trainer_kwargs={"default_root_dir": tempfile.mkdtemp()}` so each parallel worker gets its own isolated Lightning log tree.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
