### PR TITLE
chore: update from copier template v0.14.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: f4f1d235602eafd3c611bd4fa8c1efe427acde5c
+_commit: d439e067d6a4a123dc84d1c27642e2cd03356d67
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -4,13 +4,13 @@ Learn Yohou-Nixtla through focused, interactive examples. Each notebook demonstr
 
 ## Getting Started
 
-### Model Comparison ([View](/examples/model_comparison/) | [Editable](/examples/model_comparison/edit/))
+### Model Comparison ([View](/examples/model_comparison/) | [Open in marimo](/examples/model_comparison/edit/))
 
 **Comparing Statistical and Neural Forecasters**
 
 Start here to see Yohou-Nixtla's unified API in action. This example fits an `AutoARIMAForecaster` and an `NBEATSForecaster` to the classic Air Passengers dataset, then visualizes their predictions side by side. You'll understand the strengths and trade-offs of each backend while using the same `fit`/`predict` interface throughout.
 
-### Panel Data ([View](/examples/panel_data/) | [Editable](/examples/panel_data/edit/))
+### Panel Data ([View](/examples/panel_data/) | [Open in marimo](/examples/panel_data/edit/))
 
 **Forecasting Multiple Related Time Series**
 

--- a/examples/panel_data.py
+++ b/examples/panel_data.py
@@ -1,7 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "marimo",
 #     "yohou",
 #     "yohou-nixtla",
 #     "polars>=0.20",
@@ -17,28 +16,56 @@ __generated_with = "0.13.0"
 app = marimo.App(width="medium")
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     import marimo as mo
 
-    mo.md(
-        """
-        # Panel Data Forecasting
-
-        Yohou‑Nixtla handles panel (grouped) time series automatically.
-        Columns with the ``__`` separator are treated as panel groups.
-        """
-    )
     return (mo,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     from datetime import datetime, timedelta
 
     import numpy as np
+    import plotly.graph_objects as go
     import polars as pl
+    from plotly.subplots import make_subplots
 
+    from yohou_nixtla.stats import NaiveForecaster
+
+    return (NaiveForecaster, datetime, go, make_subplots, np, pl, timedelta)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        # Panel Data Forecasting
+
+        Yohou-Nixtla handles panel (grouped) time series automatically.
+        Columns with the `__` separator are treated as panel groups.
+
+        ## What You'll Learn
+
+        - How to structure panel data using the `__` column naming convention
+        - Fitting a single forecaster across multiple groups simultaneously
+        - Generating group-level predictions with the same `fit`/`predict` API
+
+        ## Prerequisites
+
+        Basic familiarity with Yohou-Nixtla's fit/predict API. See [Model Comparison](/examples/model_comparison/) for an introduction.
+        """
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"## 1. Generate Panel Data")
+
+
+@app.cell
+def _(datetime, np, pl, timedelta):
     rng = np.random.default_rng(42)
     n = 120
 
@@ -58,18 +85,16 @@ def _():
     )
 
     y.head(10)
-    return (n, np, pl, rng, time, y)
+    return (y,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
-    mo.md("## Fit and Predict")
+    mo.md(r"## 2. Fit and Predict")
 
 
 @app.cell
-def _(y):
-    from yohou_nixtla.stats import NaiveForecaster
-
+def _(NaiveForecaster, y):
     forecaster = NaiveForecaster()
     forecaster.fit(y[:100], forecasting_horizon=20)
     y_pred = forecaster.predict()
@@ -77,11 +102,13 @@ def _(y):
     return (y_pred,)
 
 
-@app.cell
-def _(y, y_pred):
-    import plotly.graph_objects as go
-    from plotly.subplots import make_subplots
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"## 3. Visualize Results")
 
+
+@app.cell
+def _(go, make_subplots, y, y_pred):
     cols = [c for c in y.columns if c != "time"]
 
     fig = make_subplots(rows=1, cols=len(cols), subplot_titles=cols)
@@ -105,6 +132,30 @@ def _(y, y_pred):
 
     fig.update_layout(title="Panel Forecasting: Two Stores", showlegend=True)
     fig
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        ## Key Takeaways
+
+        - **`__` column naming convention** automatically declares panel groups
+        - **Single forecaster** handles all groups at once -- no manual looping
+        - Predictions preserve the same panel structure as the input data
+        """
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        ## Next Steps
+
+        - **Model comparison**: See [Model Comparison](/examples/model_comparison/) to compare statistical and neural forecasters side by side
+        """
+    )
 
 
 if __name__ == "__main__":

--- a/noxfile.py
+++ b/noxfile.py
@@ -242,6 +242,8 @@ def build_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 
@@ -259,6 +261,8 @@ def serve_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 


### PR DESCRIPTION
## What

Update from copier template v0.14.0 and align docs/notebooks with the new contributing guidelines.

## Why

The template introduced marimo.app playground links (replacing local WASM exports), expanded example notebook conventions, and added the `examples` dependency group to docs builds.

## Changes

- **noxfile.py**: Add `--group examples` to `build_docs` and `serve_docs` sessions
- **docs/hooks.py**: Resolve `[Open in marimo]` links to `marimo.app` playground URLs; remove WASM export; add `--no-sandbox`, recursive glob, and error aggregation
- **docs/pages/contributing.md**: Expand "Adding Examples" with Required Structure, Marimo Cell Conventions, Content Guidelines, and PEP 723 dependency guidance
- **docs/pages/examples.md**: Replace "Editable" with "Open in marimo"
- **examples/**: Update notebooks to match new guidelines (What You'll Learn, Prerequisites, `r\"\"\"`, no pyodide, no `marimo` in PEP 723 deps)