### PR TITLE
ci: drop Python 3.14 from nightly matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:


### PR DESCRIPTION
## Description

Remove Python 3.14 from the nightly CI matrix. `scipy` has no `cp314` wheel yet, so builds fail trying to compile it from source (missing OpenBLAS).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The nightly CI included Python 3.14 in its matrix, but key dependencies (`neuralforecast` → `scipy`) don't ship 3.14 wheels yet. This caused every nightly run to fail. Dropping 3.14 until the ecosystem catches up.

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings