### PR TITLE
feat: update API from X to X_actual, add X_future and X_forecast support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ COPILOT_INSTRUCTIONS.md
 copilot-instructions.md
 copilot-config.md
 copilot-prompt.md
+.github/skills
+.github/prompts
 
 # ChatGPT / OpenAI
 CHATGPT.md
@@ -138,6 +140,7 @@ llm-instructions/
 .cursor/
 .aider*
 .continue/
+openspec/
 
 # Pytorch-Lightning
 lightning_logs/

--- a/docs/pages/explanation/concepts.md
+++ b/docs/pages/explanation/concepts.md
@@ -92,15 +92,37 @@ override `__sklearn_tags__` for exogenous feature support.
 
 ## Exogenous feature support
 
-Not all forecasters accept external regressors. By default, the base class
-tags forecasters as ignoring exogenous features. Only four forecasters override
-this: `AutoARIMAForecaster`, `ARIMAForecaster` (Stats), and
-`PatchTSTForecaster`, `TimesNetForecaster` (Neural).
+Yohou's `BasePointForecaster` defines three exogenous inputs: `X_actual`
+(historical observations only), `X_future` (known for future time steps), and
+`X_forecast` (vintage-time forecasts). Nixtla backends only support `X_future`,
+which maps to statsforecast's `X_df` and neuralforecast's `futr_exog_list`/`futr_df`.
 
-The exogenous data flows through the same conversion pipeline as the target.
-During `fit`, exogenous columns are merged into the Nixtla long-format
-DataFrame alongside the target. Yohou's `feature_transformer` applies
-preprocessing (scaling, encoding) before the data reaches the backend.
+Not all forecasters accept external regressors. Each forecaster declares a
+`supports_exogenous` tag. Passing `X_future` to a forecaster that does not
+support it raises a `ValueError` immediately, rather than failing silently
+deep in the backend. Seven forecasters currently support exogenous features:
+`AutoARIMAForecaster`, `ARIMAForecaster`, `HoltWintersForecaster` (Stats), and
+`NHITSForecaster`, `MLPForecaster`, `PatchTSTForecaster`, `TimesNetForecaster`
+(Neural).
+
+The integration bypasses yohou's step column derivation entirely. Yohou
+normally pivots `X_future` into step columns (`col_step_1`, `col_step_2`, ...),
+which makes sense for its recursive prediction loop. Nixtla backends handle
+multi-step prediction natively, so they expect raw feature columns to remain
+consistent between training and prediction. The fit method passes
+`X_future=None` to yohou's `_pre_fit` (preventing step column creation), then
+merges the raw `X_future` columns into the Nixtla training DataFrame directly.
+
+At predict time, the forecaster validates that `X_future` contains the same
+feature columns that were present during training, converts the polars
+DataFrame to Nixtla's expected format, and passes it to the backend's predict
+call. The `x_future_to_nixtla` conversion handles both single-series and panel
+data layouts automatically.
+
+`X_forecast` is explicitly rejected. Nixtla has no equivalent concept for
+vintage-time exogenous features, and silently ignoring this parameter would
+hide a configuration error. Passing `X_forecast` to any Nixtla forecaster
+raises a `ValueError` with a clear message.
 
 ## Limitations
 

--- a/docs/pages/how-to/exogenous-features.md
+++ b/docs/pages/how-to/exogenous-features.md
@@ -1,7 +1,13 @@
 # How to Use Exogenous Features
 
 This guide shows you how to incorporate external variables (exogenous features)
-into your forecasts.
+into your forecasts. Yohou-Nixtla supports two exogenous inputs:
+
+- **`X_actual`**: observation features available at training time. These go
+  through yohou's feature transformation pipeline (lags, rolling statistics)
+  before reaching the Nixtla backend.
+- **`X_future`**: known future features passed directly to the Nixtla backend
+  at both fit and predict time, bypassing yohou's feature engineering.
 
 ## Prerequisites
 
@@ -10,93 +16,164 @@ into your forecasts.
 
 ## Supported forecasters
 
-Only these forecasters accept exogenous features:
+Only certain forecasters accept exogenous features. Passing `X_future` to an
+unsupported forecaster raises a `ValueError`.
 
-| Backend | Forecaster |
-|---------|-----------|
-| Stats | `AutoARIMAForecaster`, `ARIMAForecaster` |
-| Neural | `PatchTSTForecaster`, `TimesNetForecaster` |
+| Backend | Forecaster | Exogenous support |
+|---------|-----------|-------------------|
+| Stats | `AutoARIMAForecaster` | Required |
+| Stats | `ARIMAForecaster` | Required |
+| Stats | `HoltWintersForecaster` | Optional |
+| Neural | `NHITSForecaster` | Optional |
+| Neural | `MLPForecaster` | Optional |
+| Neural | `PatchTSTForecaster` | Required |
+| Neural | `TimesNetForecaster` | Required |
 
-Other forecasters (e.g., `AutoETSForecaster`, `NBEATSForecaster`) ignore
-exogenous data. If you pass `X` to a forecaster that does not support it,
-it will be silently ignored during preprocessing.
+Models marked "Required" always expect exogenous features at both fit and
+predict time. Models marked "Optional" work with or without them.
 
-## Prepare your feature DataFrames
+## Use `X_actual` for observation features
 
-Create a polars DataFrame with a `time` column and one column per feature.
-`X_train` must have the same number of rows as `y_train`:
+`X_actual` provides historical observation features (values known only up to
+the present). These flow through yohou's `feature_transformer` pipeline, so
+lags, rolling statistics, and other engineered features are computed
+automatically.
+
+Create a polars DataFrame with a `time` column matching `y`:
 
 ```python
 import polars as pl
 
-X_train = pl.DataFrame({
+X_actual = pl.DataFrame({
+    "time": y_train["time"],
+    "temperature": [...],
+    "humidity": [...],
+})
+```
+
+Pass it to `fit`:
+
+```python
+from yohou_nixtla import AutoARIMAForecaster
+
+forecaster = AutoARIMAForecaster(season_length=12)
+forecaster.fit(y_train, X_actual=X_actual, forecasting_horizon=12)
+y_pred = forecaster.predict()
+```
+
+`X_actual` does not require a `supports_exogenous` tag on the forecaster,
+since it is processed by yohou's general feature pipeline.
+
+## Use `X_future` for known future features
+
+`X_future` provides features whose values are known in advance for the
+forecast horizon (for example, planned promotions, holidays, or scheduled
+prices). These bypass yohou's feature engineering and are passed directly
+to the Nixtla backend.
+
+### Prepare your feature DataFrames
+
+Create a polars DataFrame with a `time` column and one column per feature.
+The training DataFrame must cover the same time range as `y`:
+
+```python
+import polars as pl
+
+X_future_train = pl.DataFrame({
     "time": y_train["time"],
     "price": [...],
     "promotion": [...],
 })
 ```
 
-## Fit with exogenous features
+For prediction, create a DataFrame covering the forecast horizon:
 
-Pass `X` to `fit`. The features are merged into the Nixtla long-format
-training data automatically:
+```python
+X_future_predict = pl.DataFrame({
+    "time": future_dates,
+    "price": [...],
+    "promotion": [...],
+})
+```
+
+The predict DataFrame must contain the same feature columns as the training
+DataFrame.
+
+### Fit and predict with `X_future`
+
+Pass `X_future` to both `fit` and `predict`:
 
 ```python
 from yohou_nixtla import AutoARIMAForecaster
 
 forecaster = AutoARIMAForecaster(season_length=12)
-forecaster.fit(y_train, X=X_train, forecasting_horizon=12)
+forecaster.fit(y_train, X_future=X_future_train, forecasting_horizon=12)
+y_pred = forecaster.predict(X_future=X_future_predict)
 ```
 
-## Predict
+The features are merged into the Nixtla long-format DataFrame automatically.
+At predict time, the conversion layer validates that `X_future` contains the
+same columns that were present during training.
 
-Call `predict` with the desired horizon:
+### Panel data with `X_future`
 
-```python
-y_pred = forecaster.predict(forecasting_horizon=12)
-```
-
-## Apply feature preprocessing
-
-If your features have different scales, set a `feature_transformer` to
-normalize them before they reach the backend. The transformer is fit on
-`X_train` during `fit` and applied consistently at prediction time:
-
-```python
-from sklearn.preprocessing import StandardScaler
-from yohou_nixtla import PatchTSTForecaster
-
-forecaster = PatchTSTForecaster(
-    input_size=24,
-    max_steps=500,
-    feature_transformer=StandardScaler(),
-)
-forecaster.fit(y_train, X=X_train, forecasting_horizon=12)
-y_pred = forecaster.predict(forecasting_horizon=12)
-```
-
-## Panel data with exogenous features
-
-For panel (grouped) data, feature columns can be global or per-group. The
+For panel (grouped) data, feature columns can be per-group or global. The
 conversion module matches them automatically:
 
 ```python
 # Per-group features share the group suffix
-X_train = pl.DataFrame({
+X_future_train = pl.DataFrame({
     "time": y_train["time"],
     "price__store_1": [...],
     "price__store_2": [...],
 })
 
 # Global features (no __) are broadcast to all groups
-X_train = pl.DataFrame({
+X_future_train = pl.DataFrame({
     "time": y_train["time"],
     "oil_price": [...],
 })
 ```
 
+### Neural forecasters
+
+Neural forecasters (NHITS, MLP, PatchTST, TimesNet) receive the exogenous
+columns through neuralforecast's `futr_exog_list` parameter. This parameter is
+injected automatically during `fit` based on the columns in `X_future`:
+
+```python
+from yohou_nixtla.neural import NHITSForecaster
+
+forecaster = NHITSForecaster(input_size=24, max_steps=500)
+forecaster.fit(y_train, X_future=X_future_train, forecasting_horizon=12)
+y_pred = forecaster.predict(X_future=X_future_predict)
+```
+
+## Combine `X_actual` and `X_future`
+
+You can use both inputs together. `X_actual` feeds observation features into
+yohou's feature pipeline, while `X_future` passes known future values directly
+to the Nixtla backend:
+
+```python
+forecaster = AutoARIMAForecaster(season_length=12)
+forecaster.fit(
+    y_train,
+    X_actual=X_actual,
+    X_future=X_future_train,
+    forecasting_horizon=12,
+)
+y_pred = forecaster.predict(X_future=X_future_predict)
+```
+
+## Unsupported: `X_forecast`
+
+Nixtla backends do not support yohou's `X_forecast` parameter (vintage-time
+exogenous features). Passing `X_forecast` to any Nixtla forecaster raises a
+`ValueError`.
+
 ## See Also
 
-- [Concepts](../explanation/concepts.md): exogenous feature design
+- [Concepts](../explanation/concepts.md): exogenous feature integration design
 - [How to Choose a Forecaster](choose-forecaster.md): which forecasters support exogenous features
 - [API Reference](../reference/api.md): `fit` and `predict` method signatures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ fail_under = 100
 include_namespace_packages = true
 
 [tool.uv]
+sources = { yohou = { workspace = true } }
 # Windows wheels for `ray` (a neuralforecast dependency) are only available
 # for Python < 3.13.  Restrict lock-file resolution on Windows accordingly so
 # `uv lock` never tries to include a win_amd64 + cp313 wheel that doesn't exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "yohou>=0.1.0a5",
+    "yohou>=0.1.0a6",
     "sklearn-wrap>=0.1.0a1",
     "polars>=0.20",
     "numpy>=2.0.0",
@@ -206,8 +206,6 @@ skip_covered = false
 fail_under = 100
 include_namespace_packages = true
 
-[tool.uv]
-sources = { yohou = { workspace = true } }
 # Windows wheels for `ray` (a neuralforecast dependency) are only available
 # for Python < 3.13.  Restrict lock-file resolution on Windows accordingly so
 # `uv lock` never tries to include a win_amd64 + cp313 wheel that doesn't exist.

--- a/src/yohou_nixtla/_base.py
+++ b/src/yohou_nixtla/_base.py
@@ -28,7 +28,13 @@ from yohou.utils.panel import dict_to_panel, inspect_panel, select_panel_columns
 from yohou.utils.validate_data import validate_forecaster_data
 from yohou.utils.validation import check_groups
 
-from yohou_nixtla._conversion import infer_freq, nixtla_to_yohou, yohou_to_nixtla
+from yohou_nixtla._conversion import (
+    _add_exogenous,
+    infer_freq,
+    nixtla_to_yohou,
+    x_future_to_nixtla,
+    yohou_to_nixtla,
+)
 
 __all__ = ["BaseNixtlaForecaster"]
 
@@ -158,7 +164,14 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         super().set_params(**params)
         return self
 
-    _tags = {"uses_reduction": False, "requires_exogenous": False}
+    _tags = {"uses_reduction": False, "requires_exogenous": False, "supports_exogenous": False}
+
+    def _get_tag(self, tag_name: str) -> Any:
+        """Read a tag value from the merged ``_tags`` dicts in the MRO."""
+        for cls in type(self).__mro__:
+            if "_tags" in cls.__dict__ and tag_name in cls.__dict__["_tags"]:
+                return cls.__dict__["_tags"][tag_name]
+        return None
 
     def __sklearn_tags__(self):
         """Get estimator tags, applying ``_tags`` overrides from the class hierarchy."""
@@ -282,6 +295,13 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         if forecasting_horizon < 1:
             raise ValueError(f"forecasting_horizon must be a positive integer, got {forecasting_horizon}.")
 
+        if X_future is not None and not self._get_tag("supports_exogenous"):
+            raise ValueError(
+                f"{type(self).__name__} does not support exogenous features "
+                f"(X_future). Use a model that supports exogenous features, "
+                f"such as AutoARIMAForecaster or NHITSForecaster."
+            )
+
         if X_forecast is not None:
             raise ValueError(
                 "Nixtla backends do not support X_forecast (external forecasts "
@@ -290,11 +310,13 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
             )
 
         # 1. Yohou preprocessing: validation, panel detection, transformer fitting
+        # Pass X_future=None to _pre_fit to bypass step column derivation;
+        # Nixtla expects raw feature column names, not step columns.
         y_t, X_t = self._pre_fit(
             y=y,
             X_actual=X_actual,
             forecasting_horizon=forecasting_horizon,
-            X_future=X_future,
+            X_future=None,
             X_forecast=None,
         )
 
@@ -312,7 +334,14 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         # 5. Convert to Nixtla long format
         nixtla_df = yohou_to_nixtla(y_wide, X_wide)
 
-        # 6. Delegate to backend
+        # 6. Merge raw X_future columns into training DataFrame
+        if X_future is not None:
+            nixtla_df = _add_exogenous(nixtla_df, X_future, self.y_columns_)
+            self.futr_exog_columns_ = [c for c in X_future.columns if c != "time"]
+        else:
+            self.futr_exog_columns_ = []
+
+        # 7. Delegate to backend
         self._fit_backend(nixtla_df, forecasting_horizon)
 
         return self
@@ -378,6 +407,13 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         """
         check_is_fitted(self, ["nixtla_forecaster_", "y_columns_"])
 
+        if X_future is not None and not self._get_tag("supports_exogenous"):
+            raise ValueError(
+                f"{type(self).__name__} does not support exogenous features "
+                f"(X_future). Use a model that supports exogenous features, "
+                f"such as AutoARIMAForecaster or NHITSForecaster."
+            )
+
         if X_forecast is not None:
             raise ValueError(
                 "Nixtla backends do not support X_forecast. Use X_future for known future features instead."
@@ -388,8 +424,18 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
 
         h = forecasting_horizon if forecasting_horizon is not None else self.fit_forecasting_horizon_
 
+        # Convert X_future to Nixtla format for predict
+        nixtla_X_future = None
+        if X_future is not None and self.futr_exog_columns_:
+            x_cols = [c for c in X_future.columns if c != "time"]
+            if sorted(x_cols) != sorted(self.futr_exog_columns_):
+                raise ValueError(
+                    f"X_future columns {x_cols} do not match the columns used during fit: {self.futr_exog_columns_}."
+                )
+            nixtla_X_future = x_future_to_nixtla(X_future, self.y_columns_)
+
         # Call backend (always predicts all groups for batch efficiency)
-        forecast_df = self._predict_backend(h, X_future)
+        forecast_df = self._predict_backend(h, nixtla_X_future)
 
         # Convert back to yohou format (time + value columns)
         y_pred = nixtla_to_yohou(
@@ -416,15 +462,15 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         return select_panel_columns(result, groups, include_global=True)
 
     @abc.abstractmethod
-    def _predict_backend(self, forecasting_horizon: int, X_future: pl.DataFrame | None = None) -> Any:
+    def _predict_backend(self, forecasting_horizon: int, X_future: Any = None) -> Any:
         """Generate raw predictions from the backend orchestrator.
 
         Parameters
         ----------
         forecasting_horizon : int
             Number of steps to forecast.
-        X_future : pl.DataFrame or None, default=None
-            Known future features (already in yohou format).
+        X_future : pd.DataFrame or None, default=None
+            Known future features in Nixtla long format.
 
         Returns
         -------

--- a/src/yohou_nixtla/_base.py
+++ b/src/yohou_nixtla/_base.py
@@ -158,7 +158,7 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         super().set_params(**params)
         return self
 
-    _tags = {"uses_reduction": False, "ignores_exogenous": True}
+    _tags = {"uses_reduction": False, "requires_exogenous": False}
 
     def __sklearn_tags__(self):
         """Get estimator tags, applying ``_tags`` overrides from the class hierarchy."""
@@ -177,7 +177,7 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
     def _validate_pre_fit(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
@@ -190,16 +190,16 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         """Validate pre-fit inputs without requiring X for exogenous models.
 
         Nixtla backends manage their own feature engineering (lags,
-        exogenous columns) internally, so ``X`` is always optional
+        exogenous columns) internally, so ``X_actual`` is always optional
         regardless of ``ignores_exogenous``.  This override skips the
-        two ``target_as_feature``/``X`` checks that the base class
+        two ``target_as_feature``/``X_actual`` checks that the base class
         enforces.
 
         Parameters
         ----------
         y : pl.DataFrame
             Target time series.
-        X : pl.DataFrame or None
+        X_actual : pl.DataFrame or None
             Feature time series.
         forecasting_horizon : int
             Number of steps to forecast.
@@ -212,32 +212,31 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         -------
         y : pl.DataFrame
             Validated target.
-        X : pl.DataFrame or None
+        X_actual : pl.DataFrame or None
             Validated features.
         y_panel_groups : dict[str, list[str]]
             Panel groups from ``y``.
         X_panel_groups : dict[str, list[str]] or None
-            Panel groups from ``X``.
+            Panel groups from ``X_actual``.
 
         """
-        y, X, _ = validate_forecaster_data(self, y, X, reset=True)
+        y, X_actual, _ = validate_forecaster_data(self, y, X_actual, reset=True)
         self.fit_forecasting_horizon_ = forecasting_horizon
 
         _, y_panel_groups = inspect_panel(y)
         X_panel_groups = None
-        if X is not None:
-            _, X_panel_groups = inspect_panel(X)
+        if X_actual is not None:
+            _, X_panel_groups = inspect_panel(X_actual)
             if len(X_panel_groups) and list(X_panel_groups.keys()) != list(y_panel_groups.keys()):
-                raise ValueError("`X` and `y` do not have the same local group names.")
+                raise ValueError("`X_actual` and `y` do not have the same local group names.")
 
-        return y, X, y_panel_groups, X_panel_groups
+        return y, X_actual, y_panel_groups, X_panel_groups
 
     def fit(
         self,
         y: pl.DataFrame,
         X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
-        *,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
         **params,
@@ -292,8 +291,11 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
 
         # 1. Yohou preprocessing: validation, panel detection, transformer fitting
         y_t, X_t = self._pre_fit(
-            y=y, X=X_actual, forecasting_horizon=forecasting_horizon,
-            X_future=X_future, X_forecast=None,
+            y=y,
+            X_actual=X_actual,
+            forecasting_horizon=forecasting_horizon,
+            X_future=X_future,
+            X_forecast=None,
         )
 
         # 2. Reassemble panel dicts back to wide DataFrames
@@ -331,7 +333,6 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
 
     def predict(
         self,
-        *,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
         forecasting_horizon: int | None = None,
@@ -379,8 +380,7 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
 
         if X_forecast is not None:
             raise ValueError(
-                "Nixtla backends do not support X_forecast. "
-                "Use X_future for known future features instead."
+                "Nixtla backends do not support X_forecast. Use X_future for known future features instead."
             )
 
         # Validate and normalize groups

--- a/src/yohou_nixtla/_base.py
+++ b/src/yohou_nixtla/_base.py
@@ -179,6 +179,8 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         y: pl.DataFrame,
         X: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
     ) -> tuple[
         pl.DataFrame,
         pl.DataFrame | None,
@@ -201,6 +203,10 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
             Feature time series.
         forecasting_horizon : int
             Number of steps to forecast.
+        X_future : pl.DataFrame or None, default=None
+            Known future features.
+        X_forecast : pl.DataFrame or None, default=None
+            External forecasts.
 
         Returns
         -------
@@ -229,8 +235,11 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
     def fit(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
+        *,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         **params,
     ) -> Self:
         """Fit the Nixtla forecaster to the training data.
@@ -247,10 +256,16 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         ----------
         y : pl.DataFrame
             Target time series with ``time`` column.
-        X : pl.DataFrame or None, default=None
-            Exogenous features with ``time`` column.
+        X_actual : pl.DataFrame or None, default=None
+            Actual observation features with ``time`` column.
         forecasting_horizon : int, default=1
             Number of steps to forecast.
+        X_future : pl.DataFrame or None, default=None
+            Known future features with ``time`` column. Mapped to
+            nixtla's ``futr_exog``.
+        X_forecast : pl.DataFrame or None, default=None
+            Not supported by Nixtla backends. Raises ``ValueError``
+            if provided.
         **params : dict
             Additional metadata routing parameters.
 
@@ -262,14 +277,24 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         Raises
         ------
         ValueError
-            If ``forecasting_horizon < 1``.
+            If ``forecasting_horizon < 1`` or ``X_forecast`` is provided.
 
         """
         if forecasting_horizon < 1:
             raise ValueError(f"forecasting_horizon must be a positive integer, got {forecasting_horizon}.")
 
+        if X_forecast is not None:
+            raise ValueError(
+                "Nixtla backends do not support X_forecast (external forecasts "
+                "with vintage_time). Use X_actual for observation features or "
+                "X_future for known future features instead."
+            )
+
         # 1. Yohou preprocessing: validation, panel detection, transformer fitting
-        y_t, X_t = self._pre_fit(y=y, X=X, forecasting_horizon=forecasting_horizon)
+        y_t, X_t = self._pre_fit(
+            y=y, X=X_actual, forecasting_horizon=forecasting_horizon,
+            X_future=X_future, X_forecast=None,
+        )
 
         # 2. Reassemble panel dicts back to wide DataFrames
         y_wide = dict_to_panel(y_t)
@@ -306,7 +331,9 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
 
     def predict(
         self,
-        X: pl.DataFrame | None = None,
+        *,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         forecasting_horizon: int | None = None,
         groups: list[str] | None = None,
         predict_transformed: bool = False,
@@ -314,7 +341,7 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
     ) -> pl.DataFrame:
         """Generate point forecasts.
 
-        Overrides yohou's recursive prediction loop -- Nixtla backends
+        Overrides yohou's recursive prediction loop. Nixtla backends
         natively handle multi-step horizons, so the backend is called
         directly with the requested horizon.
 
@@ -324,8 +351,10 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
 
         Parameters
         ----------
-        X : pl.DataFrame or None, default=None
-            Future exogenous features.
+        X_future : pl.DataFrame or None, default=None
+            Known future features. Mapped to nixtla's ``futr_exog``.
+        X_forecast : pl.DataFrame or None, default=None
+            Not supported. Raises ``ValueError`` if provided.
         forecasting_horizon : int or None, default=None
             Number of steps to forecast. If None, uses the horizon from fit.
         groups : list of str or None, default=None
@@ -340,8 +369,19 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         pl.DataFrame
             Point forecasts with ``observed_time`` and ``time`` columns.
 
+        Raises
+        ------
+        ValueError
+            If ``X_forecast`` is provided.
+
         """
         check_is_fitted(self, ["nixtla_forecaster_", "y_columns_"])
+
+        if X_forecast is not None:
+            raise ValueError(
+                "Nixtla backends do not support X_forecast. "
+                "Use X_future for known future features instead."
+            )
 
         # Validate and normalize groups
         groups = check_groups(self.groups_, groups)
@@ -349,7 +389,7 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         h = forecasting_horizon if forecasting_horizon is not None else self.fit_forecasting_horizon_
 
         # Call backend (always predicts all groups for batch efficiency)
-        forecast_df = self._predict_backend(h, X)
+        forecast_df = self._predict_backend(h, X_future)
 
         # Convert back to yohou format (time + value columns)
         y_pred = nixtla_to_yohou(
@@ -376,15 +416,15 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         return select_panel_columns(result, groups, include_global=True)
 
     @abc.abstractmethod
-    def _predict_backend(self, forecasting_horizon: int, X: pl.DataFrame | None = None) -> Any:
+    def _predict_backend(self, forecasting_horizon: int, X_future: pl.DataFrame | None = None) -> Any:
         """Generate raw predictions from the backend orchestrator.
 
         Parameters
         ----------
         forecasting_horizon : int
             Number of steps to forecast.
-        X : pl.DataFrame or None, default=None
-            Future exogenous features (already in yohou format).
+        X_future : pl.DataFrame or None, default=None
+            Known future features (already in yohou format).
 
         Returns
         -------

--- a/src/yohou_nixtla/_conversion.py
+++ b/src/yohou_nixtla/_conversion.py
@@ -23,7 +23,7 @@ import polars as pl
 from yohou.utils.panel import inspect_panel
 from yohou.utils.validation import check_interval_consistency
 
-__all__ = ["infer_freq", "yohou_to_nixtla", "nixtla_to_yohou"]
+__all__ = ["infer_freq", "yohou_to_nixtla", "nixtla_to_yohou", "x_future_to_nixtla", "_add_exogenous"]
 
 # Mapping from polars interval strings to pandas offset aliases.
 # Covers the most common time series frequencies.
@@ -360,3 +360,77 @@ def nixtla_to_yohou(
         )
 
     return result
+
+
+def x_future_to_nixtla(
+    X_future: pl.DataFrame,
+    y_columns: list[str],
+) -> pd.DataFrame:
+    """Convert X_future from yohou polars wide format to Nixtla predict format.
+
+    At predict time, Nixtla backends expect a pandas DataFrame with
+    ``unique_id``, ``ds``, and feature columns. This function converts
+    the yohou polars X_future DataFrame to that format.
+
+    For panel data, feature columns are matched to ``y_columns`` by
+    prefix or suffix using the ``__`` separator. For global (non-panel)
+    data, features are broadcast to all ``y_columns``.
+
+    Parameters
+    ----------
+    X_future : pl.DataFrame
+        Known future features with ``time`` column and feature columns.
+    y_columns : list of str
+        Target column names from training, used as ``unique_id``
+        values and align panel structure.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with ``unique_id``, ``ds``, and feature columns.
+
+    """
+    x_cols = [c for c in X_future.columns if c != "time"]
+    if not x_cols:
+        raise ValueError("X_future must have at least one feature column besides 'time'.")
+
+    _, x_panel_groups = inspect_panel(X_future)
+
+    if x_panel_groups:
+        # Panel data: align X_future columns to y unique_ids
+        records: list[pd.DataFrame] = []
+        for uid in y_columns:
+            if "__" not in uid:
+                continue
+            prefix = uid.split("__", 1)[0]
+            suffix = uid.split("__", 1)[1]
+
+            uid_df = pd.DataFrame({
+                "unique_id": uid,
+                "ds": X_future.select("time").to_pandas()["time"],
+            })
+
+            # Strategy 1: prefix matching
+            matching_x_cols = [c for c in x_cols if c.startswith(f"{prefix}__")]
+            if matching_x_cols:
+                for xc in matching_x_cols:
+                    x_suffix = xc.split("__", 1)[1]
+                    uid_df[x_suffix] = X_future.get_column(xc).to_pandas().values
+            else:
+                # Strategy 2: suffix matching
+                matching_x_cols = [c for c in x_cols if c.endswith(f"__{suffix}")]
+                for xc in matching_x_cols:
+                    x_prefix = xc.split("__", 1)[0]
+                    uid_df[x_prefix] = X_future.get_column(xc).to_pandas().values
+
+            records.append(uid_df)
+        return pd.concat(records, ignore_index=True)
+    else:
+        # Global data: broadcast X_future to all unique_ids
+        x_pandas = X_future.to_pandas().rename(columns={"time": "ds"})
+        records = []
+        for uid in y_columns:
+            uid_df = x_pandas.copy()
+            uid_df["unique_id"] = uid
+            records.append(uid_df)
+        return pd.concat(records, ignore_index=True)

--- a/src/yohou_nixtla/neural/_base.py
+++ b/src/yohou_nixtla/neural/_base.py
@@ -174,11 +174,40 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         if forecasting_horizon < 1:
             raise ValueError(f"forecasting_horizon must be a positive integer, got {forecasting_horizon}.")
 
+        if X_future is not None and not self._get_tag("supports_exogenous"):
+            raise ValueError(
+                f"{type(self).__name__} does not support exogenous features "
+                f"(X_future). Use a model that supports exogenous features, "
+                f"such as AutoARIMAForecaster or NHITSForecaster."
+            )
+
         # Inject h, input_size, and max_steps into model params before
         # instantiation. neuralforecast models require h at construction.
         self.params["h"] = forecasting_horizon
         self.params["input_size"] = self.input_size
         self.params["max_steps"] = self.max_steps
+
+        # Inject futr_exog_list if X_future is provided, so the model
+        # knows which columns are future exogenous at construction time.
+        if X_future is not None:
+            futr_cols = [c for c in X_future.columns if c != "time"]
+            from yohou.utils.panel import inspect_panel
+
+            _, panel_groups = inspect_panel(X_future)
+            if panel_groups:
+                # Deduplicate: extract unique variable names from panel columns
+                seen: set[str] = set()
+                futr_exog_names: list[str] = []
+                for c in futr_cols:
+                    parts = c.split("__", 1)
+                    var_name = parts[1] if len(parts) == 2 else c
+                    if var_name not in seen:
+                        seen.add(var_name)
+                        futr_exog_names.append(var_name)
+                self.params["futr_exog_list"] = futr_exog_names
+            else:
+                self.params["futr_exog_list"] = futr_cols
+
         self.instantiate()
 
         return super().fit(
@@ -210,7 +239,7 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         nf.fit(df=nixtla_df)
         self.nixtla_forecaster_ = nf
 
-    def _predict_backend(self, forecasting_horizon: int, X_future: pl.DataFrame | None = None) -> Any:
+    def _predict_backend(self, forecasting_horizon: int, X_future: Any = None) -> Any:
         """Generate raw predictions from the NeuralForecast orchestrator.
 
         Neural models always predict exactly ``h`` steps (the horizon set
@@ -221,8 +250,9 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         ----------
         forecasting_horizon : int
             Number of steps to forecast.
-        X_future : pl.DataFrame or None, default=None
-            Known future features (unused currently).
+        X_future : pd.DataFrame or None, default=None
+            Known future features in Nixtla long format, passed as
+            ``futr_df`` to ``NeuralForecast.predict()``.
 
         Returns
         -------
@@ -231,7 +261,7 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
 
         """
         check_is_fitted(self, ["nixtla_forecaster_"])
-        return self.nixtla_forecaster_.predict()
+        return self.nixtla_forecaster_.predict(futr_df=X_future)
 
     def predict(
         self,

--- a/src/yohou_nixtla/neural/_base.py
+++ b/src/yohou_nixtla/neural/_base.py
@@ -133,8 +133,11 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
     def fit(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
+        *,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         **params,
     ) -> BaseNeuralForecaster:
         """Fit the neural forecaster to the training data.
@@ -147,10 +150,14 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         ----------
         y : pl.DataFrame
             Target time series with ``time`` column.
-        X : pl.DataFrame or None, default=None
-            Exogenous features with ``time`` column.
+        X_actual : pl.DataFrame or None, default=None
+            Actual observation features with ``time`` column.
         forecasting_horizon : int, default=1
             Number of steps to forecast.
+        X_future : pl.DataFrame or None, default=None
+            Known future features with ``time`` column.
+        X_forecast : pl.DataFrame or None, default=None
+            Not supported. Raises ``ValueError`` if provided.
         **params : dict
             Additional metadata routing parameters.
 
@@ -162,7 +169,7 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         Raises
         ------
         ValueError
-            If ``forecasting_horizon < 1``.
+            If ``forecasting_horizon < 1`` or ``X_forecast`` is provided.
 
         """
         if forecasting_horizon < 1:
@@ -175,7 +182,10 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         self.params["max_steps"] = self.max_steps
         self.instantiate()
 
-        return super().fit(y=y, X=X, forecasting_horizon=forecasting_horizon, **params)
+        return super().fit(
+            y=y, X_actual=X_actual, forecasting_horizon=forecasting_horizon,
+            X_future=X_future, X_forecast=X_forecast, **params,
+        )
 
     def _fit_backend(self, nixtla_df: Any, forecasting_horizon: int) -> None:
         """Create and fit the NeuralForecast orchestrator.
@@ -197,7 +207,7 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         nf.fit(df=nixtla_df)
         self.nixtla_forecaster_ = nf
 
-    def _predict_backend(self, forecasting_horizon: int, X: pl.DataFrame | None = None) -> Any:
+    def _predict_backend(self, forecasting_horizon: int, X_future: pl.DataFrame | None = None) -> Any:
         """Generate raw predictions from the NeuralForecast orchestrator.
 
         Neural models always predict exactly ``h`` steps (the horizon set
@@ -208,8 +218,8 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         ----------
         forecasting_horizon : int
             Number of steps to forecast.
-        X : pl.DataFrame or None, default=None
-            Future exogenous features (unused currently).
+        X_future : pl.DataFrame or None, default=None
+            Known future features (unused currently).
 
         Returns
         -------
@@ -222,7 +232,9 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
 
     def predict(
         self,
-        X: pl.DataFrame | None = None,
+        *,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         forecasting_horizon: int | None = None,
         groups: list[str] | None = None,
         predict_transformed: bool = False,
@@ -236,8 +248,10 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
 
         Parameters
         ----------
-        X : pl.DataFrame or None, default=None
-            Future exogenous features.
+        X_future : pl.DataFrame or None, default=None
+            Known future features.
+        X_forecast : pl.DataFrame or None, default=None
+            Not supported. Raises ``ValueError`` if provided.
         forecasting_horizon : int or None, default=None
             Number of steps to forecast. If None, uses the horizon from fit.
         groups : list of str or None, default=None
@@ -256,7 +270,8 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         check_is_fitted(self, ["nixtla_forecaster_"])
 
         y_pred = super().predict(
-            X=X,
+            X_future=X_future,
+            X_forecast=X_forecast,
             forecasting_horizon=self.fit_forecasting_horizon_,
             groups=groups,
             predict_transformed=predict_transformed,

--- a/src/yohou_nixtla/neural/_base.py
+++ b/src/yohou_nixtla/neural/_base.py
@@ -135,7 +135,6 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         y: pl.DataFrame,
         X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
-        *,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
         **params,
@@ -183,8 +182,12 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
         self.instantiate()
 
         return super().fit(
-            y=y, X_actual=X_actual, forecasting_horizon=forecasting_horizon,
-            X_future=X_future, X_forecast=X_forecast, **params,
+            y=y,
+            X_actual=X_actual,
+            forecasting_horizon=forecasting_horizon,
+            X_future=X_future,
+            X_forecast=X_forecast,
+            **params,
         )
 
     def _fit_backend(self, nixtla_df: Any, forecasting_horizon: int) -> None:
@@ -232,7 +235,6 @@ class BaseNeuralForecaster(BaseNixtlaForecaster):
 
     def predict(
         self,
-        *,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
         forecasting_horizon: int | None = None,

--- a/src/yohou_nixtla/neural/_forecasters.py
+++ b/src/yohou_nixtla/neural/_forecasters.py
@@ -120,6 +120,8 @@ class NHITSForecaster(BaseNeuralForecaster):
 
     _estimator_default_class = NHITS
 
+    _tags = {"supports_exogenous": True}
+
 
 class MLPForecaster(BaseNeuralForecaster):
     """MLP (Multi-Layer Perceptron) forecaster via neuralforecast.
@@ -166,6 +168,8 @@ class MLPForecaster(BaseNeuralForecaster):
     """
 
     _estimator_default_class = MLP
+
+    _tags = {"supports_exogenous": True}
 
 
 class PatchTSTForecaster(BaseNeuralForecaster):
@@ -221,7 +225,7 @@ class PatchTSTForecaster(BaseNeuralForecaster):
 
     _estimator_default_class = PatchTST
 
-    _tags = {"requires_exogenous": True}
+    _tags = {"requires_exogenous": True, "supports_exogenous": True}
 
 
 class TimesNetForecaster(BaseNeuralForecaster):
@@ -277,4 +281,4 @@ class TimesNetForecaster(BaseNeuralForecaster):
 
     _estimator_default_class = TimesNet
 
-    _tags = {"requires_exogenous": True}
+    _tags = {"requires_exogenous": True, "supports_exogenous": True}

--- a/src/yohou_nixtla/neural/_forecasters.py
+++ b/src/yohou_nixtla/neural/_forecasters.py
@@ -221,7 +221,7 @@ class PatchTSTForecaster(BaseNeuralForecaster):
 
     _estimator_default_class = PatchTST
 
-    _tags = {"ignores_exogenous": False}
+    _tags = {"requires_exogenous": True}
 
 
 class TimesNetForecaster(BaseNeuralForecaster):
@@ -277,4 +277,4 @@ class TimesNetForecaster(BaseNeuralForecaster):
 
     _estimator_default_class = TimesNet
 
-    _tags = {"ignores_exogenous": False}
+    _tags = {"requires_exogenous": True}

--- a/src/yohou_nixtla/stats/_base.py
+++ b/src/yohou_nixtla/stats/_base.py
@@ -65,8 +65,11 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
     def fit(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
+        *,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         **params,
     ) -> BaseStatsForecaster:
         """Fit the statsforecast model to the training data.
@@ -75,10 +78,14 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
         ----------
         y : pl.DataFrame
             Target time series with ``time`` column.
-        X : pl.DataFrame or None, default=None
-            Exogenous features with ``time`` column.
+        X_actual : pl.DataFrame or None, default=None
+            Actual observation features with ``time`` column.
         forecasting_horizon : int, default=1
             Number of steps to forecast.
+        X_future : pl.DataFrame or None, default=None
+            Known future features with ``time`` column.
+        X_forecast : pl.DataFrame or None, default=None
+            Not supported. Raises ``ValueError`` if provided.
         **params : dict
             Additional metadata routing parameters.
 
@@ -88,7 +95,10 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
             Fitted forecaster.
 
         """
-        return super().fit(y=y, X=X, forecasting_horizon=forecasting_horizon, **params)
+        return super().fit(
+            y=y, X_actual=X_actual, forecasting_horizon=forecasting_horizon,
+            X_future=X_future, X_forecast=X_forecast, **params,
+        )
 
     def _fit_backend(self, nixtla_df: Any, forecasting_horizon: int) -> None:
         """Create and fit the StatsForecast orchestrator.
@@ -108,15 +118,15 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
         sf.fit(df=nixtla_df)
         self.nixtla_forecaster_ = sf
 
-    def _predict_backend(self, forecasting_horizon: int, X: pl.DataFrame | None = None) -> Any:
+    def _predict_backend(self, forecasting_horizon: int, X_future: pl.DataFrame | None = None) -> Any:
         """Generate raw predictions from the StatsForecast orchestrator.
 
         Parameters
         ----------
         forecasting_horizon : int
             Number of steps to forecast.
-        X : pl.DataFrame or None, default=None
-            Future exogenous features (unused by stats models).
+        X_future : pl.DataFrame or None, default=None
+            Known future features (unused by stats models).
 
         Returns
         -------

--- a/src/yohou_nixtla/stats/_base.py
+++ b/src/yohou_nixtla/stats/_base.py
@@ -121,15 +121,16 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
         sf.fit(df=nixtla_df)
         self.nixtla_forecaster_ = sf
 
-    def _predict_backend(self, forecasting_horizon: int, X_future: pl.DataFrame | None = None) -> Any:
+    def _predict_backend(self, forecasting_horizon: int, X_future: Any = None) -> Any:
         """Generate raw predictions from the StatsForecast orchestrator.
 
         Parameters
         ----------
         forecasting_horizon : int
             Number of steps to forecast.
-        X_future : pl.DataFrame or None, default=None
-            Known future features (unused by stats models).
+        X_future : pd.DataFrame or None, default=None
+            Known future features in Nixtla long format, passed as
+            ``X_df`` to ``StatsForecast.predict()``.
 
         Returns
         -------
@@ -138,4 +139,4 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
 
         """
         check_is_fitted(self, ["nixtla_forecaster_"])
-        return self.nixtla_forecaster_.predict(h=forecasting_horizon)
+        return self.nixtla_forecaster_.predict(h=forecasting_horizon, X_df=X_future)

--- a/src/yohou_nixtla/stats/_base.py
+++ b/src/yohou_nixtla/stats/_base.py
@@ -67,7 +67,6 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
         y: pl.DataFrame,
         X_actual: pl.DataFrame | None = None,
         forecasting_horizon: int = 1,
-        *,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
         **params,
@@ -96,8 +95,12 @@ class BaseStatsForecaster(BaseNixtlaForecaster):
 
         """
         return super().fit(
-            y=y, X_actual=X_actual, forecasting_horizon=forecasting_horizon,
-            X_future=X_future, X_forecast=X_forecast, **params,
+            y=y,
+            X_actual=X_actual,
+            forecasting_horizon=forecasting_horizon,
+            X_future=X_future,
+            X_forecast=X_forecast,
+            **params,
         )
 
     def _fit_backend(self, nixtla_df: Any, forecasting_horizon: int) -> None:

--- a/src/yohou_nixtla/stats/_forecasters.py
+++ b/src/yohou_nixtla/stats/_forecasters.py
@@ -76,7 +76,7 @@ class AutoARIMAForecaster(BaseStatsForecaster):
 
     _estimator_default_class = AutoARIMA
 
-    _tags = {"ignores_exogenous": False}
+    _tags = {"requires_exogenous": True}
 
 
 class AutoETSForecaster(BaseStatsForecaster):
@@ -351,7 +351,7 @@ class ARIMAForecaster(BaseStatsForecaster):
 
     _estimator_default_class = ARIMA
 
-    _tags = {"ignores_exogenous": False}
+    _tags = {"requires_exogenous": True}
 
 
 class HoltWintersForecaster(BaseStatsForecaster):

--- a/src/yohou_nixtla/stats/_forecasters.py
+++ b/src/yohou_nixtla/stats/_forecasters.py
@@ -76,7 +76,7 @@ class AutoARIMAForecaster(BaseStatsForecaster):
 
     _estimator_default_class = AutoARIMA
 
-    _tags = {"requires_exogenous": True}
+    _tags = {"requires_exogenous": True, "supports_exogenous": True}
 
 
 class AutoETSForecaster(BaseStatsForecaster):
@@ -351,7 +351,7 @@ class ARIMAForecaster(BaseStatsForecaster):
 
     _estimator_default_class = ARIMA
 
-    _tags = {"requires_exogenous": True}
+    _tags = {"requires_exogenous": True, "supports_exogenous": True}
 
 
 class HoltWintersForecaster(BaseStatsForecaster):
@@ -399,6 +399,8 @@ class HoltWintersForecaster(BaseStatsForecaster):
     """
 
     _estimator_default_class = HoltWinters
+
+    _tags = {"supports_exogenous": True}
 
 
 class ThetaForecaster(BaseStatsForecaster):

--- a/tests/test_exogenous.py
+++ b/tests/test_exogenous.py
@@ -1,0 +1,336 @@
+"""Tests for exogenous feature (X_future) integration with Nixtla backends.
+
+Covers:
+- fit/predict with X_future on stats and neural models
+- Panel data with X_future
+- Per-model gating (supports_exogenous tag)
+- Column mismatch validation at predict time
+- Combined X_actual + X_future
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from yohou_nixtla.stats import (
+    AutoARIMAForecaster,
+    NaiveForecaster,
+)
+
+
+def _make_daily_data(length=100, n_targets=1, n_future_features=1, seed=42, panel=False, n_groups=2):
+    """Generate y and X_future test data with daily frequency.
+
+    Returns (y, X_future) where X_future covers `length + horizon` days
+    to provide future values at predict time.
+    """
+    rng = np.random.default_rng(seed)
+    horizon = 5
+    total_length = length + horizon
+
+    time_train = pl.datetime_range(
+        start=datetime(2020, 1, 1),
+        end=datetime(2020, 1, 1) + timedelta(days=length - 1),
+        interval="1d",
+        eager=True,
+    )
+    time_future = pl.datetime_range(
+        start=datetime(2020, 1, 1) + timedelta(days=length),
+        end=datetime(2020, 1, 1) + timedelta(days=total_length - 1),
+        interval="1d",
+        eager=True,
+    )
+
+    if panel:
+        y = pl.DataFrame({"time": time_train})
+        X_future_fit = pl.DataFrame({"time": time_train})
+        X_future_predict = pl.DataFrame({"time": time_future})
+        for group_idx in range(n_groups):
+            for i in range(n_targets):
+                col_name = f"group_{group_idx}__y_{i}"
+                y = y.with_columns(pl.Series(col_name, rng.random(length) * 100))
+            for i in range(n_future_features):
+                col_name = f"group_{group_idx}__f_{i}"
+                X_future_fit = X_future_fit.with_columns(pl.Series(col_name, rng.random(length) * 10))
+                X_future_predict = X_future_predict.with_columns(pl.Series(col_name, rng.random(horizon) * 10))
+    else:
+        y = pl.DataFrame({"time": time_train})
+        for i in range(n_targets):
+            y = y.with_columns(pl.Series(f"y_{i}", rng.random(length) * 100))
+
+        X_future_fit = pl.DataFrame({"time": time_train})
+        X_future_predict = pl.DataFrame({"time": time_future})
+        for i in range(n_future_features):
+            X_future_fit = X_future_fit.with_columns(pl.Series(f"f_{i}", rng.random(length) * 10))
+            X_future_predict = X_future_predict.with_columns(pl.Series(f"f_{i}", rng.random(horizon) * 10))
+
+    return y, X_future_fit, X_future_predict, horizon
+
+
+class TestStatsExogenous:
+    """Tests for X_future with statsforecast models."""
+
+    def test_fit_predict_with_x_future(self):
+        """AutoARIMA should fit and predict with X_future."""
+        y, X_future_fit, X_future_predict, horizon = _make_daily_data()
+
+        forecaster = AutoARIMAForecaster()
+        forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=horizon)
+        result = forecaster.predict(X_future=X_future_predict)
+
+        assert "time" in result.columns
+        assert result.shape[0] == horizon
+
+    def test_fit_predict_panel_with_x_future(self):
+        """AutoARIMA should fit and predict with X_future on panel data."""
+        y, X_future_fit, X_future_predict, horizon = _make_daily_data(panel=True)
+
+        forecaster = AutoARIMAForecaster()
+        forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=horizon)
+        result = forecaster.predict(X_future=X_future_predict)
+
+        assert "time" in result.columns
+        assert result.shape[0] == horizon
+        # Should have columns for both groups
+        value_cols = [c for c in result.columns if c not in ("time", "observed_time", "vintage_time")]
+        assert len(value_cols) == 2
+
+    def test_fit_predict_with_x_actual_and_x_future(self):
+        """AutoARIMA should fit with both X_actual and X_future.
+
+        When both X_actual and X_future are provided, both sets of columns
+        end up in the Nixtla training DataFrame. Verify that fit succeeds
+        and the model stores the correct attributes.
+        """
+        rng = np.random.default_rng(123)
+        length = 100
+        horizon = 5
+        time_train = pl.datetime_range(
+            start=datetime(2020, 1, 1),
+            end=datetime(2020, 1, 1) + timedelta(days=length - 1),
+            interval="1d",
+            eager=True,
+        )
+
+        # Create y that depends on the features
+        x_actual_vals = rng.random(length) * 10
+        x_future_vals_fit = rng.random(length) * 5
+        y_vals = 50 + 2 * x_actual_vals + 1.5 * x_future_vals_fit + rng.normal(0, 1, length)
+
+        y = pl.DataFrame({"time": time_train, "y_0": y_vals})
+        X_actual = pl.DataFrame({"time": time_train, "actual_feat": x_actual_vals})
+        X_future_fit = pl.DataFrame({"time": time_train, "future_feat": x_future_vals_fit})
+
+        forecaster = AutoARIMAForecaster()
+        forecaster.fit(
+            y,
+            X_actual=X_actual,
+            X_future=X_future_fit,
+            forecasting_horizon=horizon,
+        )
+
+        # Verify X_future columns were stored
+        assert forecaster.futr_exog_columns_ == ["future_feat"]
+
+
+class TestNeuralExogenous:
+    """Tests for X_future with neuralforecast models."""
+
+    def test_fit_predict_with_x_future(self):
+        """NHITS should fit and predict with X_future."""
+        from yohou_nixtla.neural import NHITSForecaster
+
+        y, X_future_fit, X_future_predict, horizon = _make_daily_data()
+
+        forecaster = NHITSForecaster(input_size=12, max_steps=5)
+        forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=horizon)
+        result = forecaster.predict(X_future=X_future_predict)
+
+        assert "time" in result.columns
+        assert result.shape[0] == horizon
+
+
+class TestExogenousGating:
+    """Tests for per-model exogenous gating."""
+
+    def test_unsupported_model_raises_on_fit(self):
+        """NaiveForecaster should raise ValueError when X_future is provided at fit."""
+        y, X_future_fit, _, _ = _make_daily_data()
+
+        forecaster = NaiveForecaster()
+        with pytest.raises(ValueError, match="does not support exogenous features"):
+            forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=5)
+
+    def test_unsupported_model_raises_on_predict(self, daily_y_X_factory):
+        """NaiveForecaster should raise ValueError when X_future is provided at predict."""
+        y, _ = daily_y_X_factory(length=100)
+
+        forecaster = NaiveForecaster()
+        forecaster.fit(y, forecasting_horizon=5)
+
+        _, _, X_future_predict, _ = _make_daily_data()
+        with pytest.raises(ValueError, match="does not support exogenous features"):
+            forecaster.predict(X_future=X_future_predict)
+
+    def test_unsupported_neural_model_raises_on_fit(self):
+        """NBEATSForecaster should raise ValueError when X_future is provided."""
+        from yohou_nixtla.neural import NBEATSForecaster
+
+        y, X_future_fit, _, _ = _make_daily_data()
+
+        forecaster = NBEATSForecaster(input_size=12, max_steps=5)
+        with pytest.raises(ValueError, match="does not support exogenous features"):
+            forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=5)
+
+    def test_x_forecast_raises(self):
+        """Any model should raise ValueError when X_forecast is provided."""
+        y, X_future_fit, _, _ = _make_daily_data()
+
+        forecaster = AutoARIMAForecaster()
+        with pytest.raises(ValueError, match="do not support X_forecast"):
+            forecaster.fit(y, X_forecast=X_future_fit, forecasting_horizon=5)
+
+    def test_x_forecast_predict_raises(self, daily_y_X_factory):
+        """Predict with X_forecast should raise ValueError."""
+        y, _ = daily_y_X_factory(length=100)
+
+        forecaster = AutoARIMAForecaster()
+        forecaster.fit(y, forecasting_horizon=5)
+
+        _, X_future_fit, _, _ = _make_daily_data()
+        with pytest.raises(ValueError, match="do not support X_forecast"):
+            forecaster.predict(X_forecast=X_future_fit)
+
+
+class TestExogenousValidation:
+    """Tests for predict-time column validation."""
+
+    def test_column_mismatch_raises(self):
+        """Predict with different X_future columns should raise ValueError."""
+        y, X_future_fit, _, horizon = _make_daily_data()
+
+        forecaster = AutoARIMAForecaster()
+        forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=horizon)
+
+        # Create X_future with different column names
+        time_future = pl.datetime_range(
+            start=datetime(2020, 4, 11),
+            end=datetime(2020, 4, 11) + timedelta(days=horizon - 1),
+            interval="1d",
+            eager=True,
+        )
+        X_future_wrong = pl.DataFrame({
+            "time": time_future,
+            "wrong_column": [1.0] * horizon,
+        })
+
+        with pytest.raises(ValueError, match="do not match"):
+            forecaster.predict(X_future=X_future_wrong)
+
+
+class TestGetTag:
+    """Tests for the _get_tag helper method."""
+
+    def test_get_tag_returns_none_for_unknown(self):
+        """_get_tag should return None for a tag not defined anywhere."""
+        forecaster = NaiveForecaster()
+        assert forecaster._get_tag("nonexistent_tag") is None
+
+
+class TestXFutureToNixtla:
+    """Tests for x_future_to_nixtla conversion edge cases."""
+
+    def test_empty_x_future_raises(self):
+        """X_future with only a time column should raise ValueError."""
+        from yohou_nixtla._conversion import x_future_to_nixtla
+
+        X = pl.DataFrame({"time": [datetime(2020, 1, 1)]})
+        with pytest.raises(ValueError, match="at least one feature column"):
+            x_future_to_nixtla(X, y_columns=["y_0"])
+
+    def test_panel_suffix_matching(self):
+        """Panel X_future should use suffix matching when prefix doesn't match."""
+        from yohou_nixtla._conversion import x_future_to_nixtla
+
+        time = [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+        # y columns use prefix__suffix format: target__store_1
+        y_columns = ["target__store_1", "target__store_2"]
+        # X_future uses variable__suffix format: feature__store_1
+        X_future = pl.DataFrame({
+            "time": time,
+            "feature__store_1": [1.0, 2.0],
+            "feature__store_2": [3.0, 4.0],
+        })
+
+        result = x_future_to_nixtla(X_future, y_columns)
+        assert set(result["unique_id"].unique()) == {"target__store_1", "target__store_2"}
+        assert "feature" in result.columns
+
+    def test_panel_skips_uid_without_separator(self):
+        """Panel X_future should skip y_columns entries without __ separator."""
+        from yohou_nixtla._conversion import x_future_to_nixtla
+
+        time = [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+        # y_columns has both panel and non-panel entries
+        y_columns = ["global_col", "group_0__y_0"]
+        X_future = pl.DataFrame({
+            "time": time,
+            "group_0__f_0": [1.0, 2.0],
+        })
+
+        result = x_future_to_nixtla(X_future, y_columns)
+        # Only the panel entry should be in the result
+        assert list(result["unique_id"].unique()) == ["group_0__y_0"]
+
+
+class TestNeuralPanelExogenous:
+    """Tests for neural model with panel exogenous features."""
+
+    def test_fit_with_panel_x_future_deduplicates_futr_exog_list(self):
+        """Neural model should deduplicate panel X_future columns into futr_exog_list."""
+        from yohou_nixtla.neural import NHITSForecaster
+
+        rng = np.random.default_rng(42)
+        length = 100
+        horizon = 5
+        time_train = pl.datetime_range(
+            start=datetime(2020, 1, 1),
+            end=datetime(2020, 1, 1) + timedelta(days=length - 1),
+            interval="1d",
+            eager=True,
+        )
+        time_future = pl.datetime_range(
+            start=datetime(2020, 1, 1) + timedelta(days=length),
+            end=datetime(2020, 1, 1) + timedelta(days=length + horizon - 1),
+            interval="1d",
+            eager=True,
+        )
+
+        y = pl.DataFrame({
+            "time": time_train,
+            "group_0__y_0": rng.random(length) * 100,
+            "group_1__y_0": rng.random(length) * 100,
+        })
+        X_future_fit = pl.DataFrame({
+            "time": time_train,
+            "group_0__f_0": rng.random(length) * 10,
+            "group_1__f_0": rng.random(length) * 10,
+        })
+        X_future_predict = pl.DataFrame({
+            "time": time_future,
+            "group_0__f_0": rng.random(horizon) * 10,
+            "group_1__f_0": rng.random(horizon) * 10,
+        })
+
+        forecaster = NHITSForecaster(input_size=12, max_steps=5)
+        forecaster.fit(y, X_future=X_future_fit, forecasting_horizon=horizon)
+
+        # futr_exog_list should have deduplicated names (just "f_0")
+        assert forecaster.params.get("futr_exog_list") == ["f_0"]
+
+        result = forecaster.predict(X_future=X_future_predict)
+        assert result.shape[0] == horizon

--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -591,19 +591,19 @@ class TestIgnoresExogenous:
             pytest.skip(f"{neural_cls.__name__} supports exogenous")
         forecaster = neural_cls()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is True
+        assert tags.forecaster_tags.requires_exogenous is False
 
     def test_patchtst_supports_exogenous(self):
         """PatchTST should support exogenous features."""
         forecaster = PatchTSTForecaster()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is False
+        assert tags.forecaster_tags.requires_exogenous is True
 
     def test_timesnet_supports_exogenous(self):
         """TimesNet should support exogenous features."""
         forecaster = TimesNetForecaster()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is False
+        assert tags.forecaster_tags.requires_exogenous is True
 
 
 class TestFitValidation:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -434,7 +434,7 @@ class TestPanelData:
         })
         forecaster = NaiveForecaster()
         with pytest.raises(ValueError, match="do not have the same local group names"):
-            forecaster.fit(y, X, forecasting_horizon=3)
+            forecaster.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_panel_fit_with_matching_exogenous(self):
         """Panel X with matching group names is accepted without error."""
@@ -458,7 +458,7 @@ class TestPanelData:
             "group_1__feature": list(range(60, 120)),
         })
         forecaster = NaiveForecaster()
-        forecaster.fit(y, X, forecasting_horizon=3)
+        forecaster.fit(y, X_actual=X, forecasting_horizon=3)
         y_pred = forecaster.predict()
         assert len(y_pred) == 3
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -782,49 +782,49 @@ class TestTransformerIntegration:
 
 
 class TestIgnoresExogenous:
-    """Tests for per-model ignores_exogenous tags."""
+    """Tests for per-model requires_exogenous tags."""
 
     def test_naive_ignores_exogenous(self):
         """Naive models should ignore exogenous features."""
         forecaster = NaiveForecaster()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is True
+        assert tags.forecaster_tags.requires_exogenous is False
 
     def test_seasonal_naive_ignores_exogenous(self):
         """Seasonal naive should ignore exogenous features."""
         forecaster = SeasonalNaiveForecaster(season_length=7)
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is True
+        assert tags.forecaster_tags.requires_exogenous is False
 
     def test_croston_ignores_exogenous(self):
         """Croston should ignore exogenous features."""
         forecaster = CrostonForecaster()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is True
+        assert tags.forecaster_tags.requires_exogenous is False
 
     def test_arima_supports_exogenous(self):
         """ARIMA models should support exogenous features."""
         forecaster = ARIMAForecaster(order=(1, 0, 0))
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is False
+        assert tags.forecaster_tags.requires_exogenous is True
 
     def test_auto_arima_supports_exogenous(self):
         """AutoARIMA should support exogenous features."""
         forecaster = AutoARIMAForecaster()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is False
+        assert tags.forecaster_tags.requires_exogenous is True
 
     def test_holt_winters_ignores_exogenous(self):
         """HoltWinters should ignore exogenous features (default tag)."""
         forecaster = HoltWintersForecaster(season_length=7)
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is True
+        assert tags.forecaster_tags.requires_exogenous is False
 
     def test_theta_ignores_exogenous(self):
         """Theta should ignore exogenous features (default tag)."""
         forecaster = ThetaForecaster()
         tags = forecaster.__sklearn_tags__()
-        assert tags.forecaster_tags.ignores_exogenous is True
+        assert tags.forecaster_tags.requires_exogenous is False
 
 
 class TestFitValidation:
@@ -847,6 +847,21 @@ class TestFitValidation:
         y_pred = forecaster._convert_nixtla_to_yohou(forecast_df, reset_index=False)
         assert isinstance(y_pred, pl.DataFrame)
         assert "time" in y_pred.columns
+
+    def test_x_forecast_rejected_on_fit(self, fast_forecaster_cls, daily_y_X_factory):
+        """Passing X_forecast to fit should raise ValueError."""
+        y, X = daily_y_X_factory(length=60, n_features=1)
+        forecaster = _make_forecaster(fast_forecaster_cls)
+        with pytest.raises(ValueError, match="Nixtla backends do not support X_forecast"):
+            forecaster.fit(y, X_forecast=X)
+
+    def test_x_forecast_rejected_on_predict(self, fast_forecaster_cls, daily_y_X_factory):
+        """Passing X_forecast to predict should raise ValueError."""
+        y, X = daily_y_X_factory(length=60, n_features=1)
+        forecaster = _make_forecaster(fast_forecaster_cls)
+        forecaster.fit(y, forecasting_horizon=3)
+        with pytest.raises(ValueError, match="Nixtla backends do not support X_forecast"):
+            forecaster.predict(X_forecast=X)
 
 
 class TestSystematicChecks:


### PR DESCRIPTION
## Description

Rename the exogenous parameter from `X` to `X_actual` across the public API. Add `X_future` and `X_forecast` forwarding to the base nixtla adapter and both stats and neural forecaster subclasses.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Align with the new yohou core exogenous features API (`X_actual`, `X_future`, `X_forecast`).

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Companion PR to stateful-y/yohou#56.