### PR TITLE
test: isolate lightning_logs per test to fix xdist race

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib
 from collections.abc import Generator
 from datetime import datetime, timedelta
 from typing import Any
@@ -9,6 +10,24 @@ from typing import Any
 import numpy as np
 import polars as pl
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every test its own working directory.
+
+    neuralforecast delegates training to a ``pytorch_lightning.Trainer`` whose
+    ``default_root_dir`` defaults to the process working directory, so each
+    ``fit`` writes a ``lightning_logs/version_N`` directory there. Lightning
+    chooses ``N`` by listing that directory and taking ``max + 1``, then creates
+    it through ``SummaryWriter`` with ``exist_ok=False``. That read-then-create
+    is not atomic: under ``pytest -n auto`` two workers can settle on the same
+    ``N`` before either creates it, and the loser dies with ``FileExistsError``.
+
+    Isolating the working directory removes the shared directory the workers
+    were racing on, and keeps training artefacts out of the repository root.
+    """
+    monkeypatch.chdir(tmp_path)
 
 
 def run_checks(

--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -8,8 +8,6 @@ Covers ``BaseNeuralForecaster`` and concrete wrapper classes:
 
 from __future__ import annotations
 
-import tempfile
-
 import polars as pl
 import pytest
 from sklearn.base import clone
@@ -326,14 +324,12 @@ class TestFitPredict:
 
 def _make_neural_forecaster(cls, **extra_kwargs):
     """Create a neural forecaster with sensible defaults for fast testing."""
+    # The ``lightning_logs`` directory each fit writes is isolated per test by the
+    # autouse ``_isolated_cwd`` fixture in ``conftest.py``, so no ``default_root_dir``
+    # override is needed here.
     defaults = {
         "input_size": 12,
         "max_steps": 5,
-        # Use a unique temp directory so parallel xdist workers don't race on
-        # the shared ``lightning_logs/version_N`` directory.
-        # neuralforecast forwards unknown kwargs straight to pl.Trainer, so
-        # ``default_root_dir`` is passed at the top level, not nested.
-        "default_root_dir": tempfile.mkdtemp(),
     }
     # Per-model architecture reduction for faster tests.
     _model_defaults = {


### PR DESCRIPTION
## Description

Fixes the recurring CI flake where a neural test dies with
`FileExistsError: [Errno 17] File exists: '.../lightning_logs/version_2'`, most often seen as
`tests/test_exogenous.py::TestNeuralPanelExogenous::test_fit_with_panel_x_future_deduplicates_futr_exog_list`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

A TOCTOU race between xdist workers, not a defect in the test itself.

Every neural `fit` delegates to a `pytorch_lightning.Trainer` whose `default_root_dir` defaults to the
**process working directory**, so it writes `lightning_logs/version_N` there. Lightning picks `N` by
listing that directory and taking `max + 1` (`_get_next_version`), then creates it via `SummaryWriter`
with `exist_ok=False` (`lightning_fabric/loggers/tensorboard.py:195`).

That read-then-create is not atomic. The suite runs `-n auto`, so all workers shared a single
`lightning_logs/` in the repository root: two workers could settle on the same `N` before either created
it, and the loser raised `FileExistsError`.

The mechanism was confirmed rather than inferred — instrumenting `os.makedirs` surfaced the
`exist_ok=False` call and its full stack through `neuralforecast` → `Trainer.fit` → `logger.experiment`.

`test_exogenous.py` was not special; it just lost the race that particular time. **~19 fit sites across
`test_neural.py` and `test_exogenous.py` were equally exposed** — only those going through
`_make_neural_forecaster` had a workaround.

### Approach

An autouse fixture in `tests/conftest.py` gives each test its own cwd via `monkeypatch.chdir(tmp_path)`.
This removes the contended directory outright instead of patching call sites, so tests added later are
covered by default — something the per-call-site approach could not guarantee.

The now-redundant `default_root_dir=tempfile.mkdtemp()` override is dropped; it leaked a temp directory
per forecaster with no cleanup.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly <!-- n/a: test-infrastructure only -->
- [ ] I have added tests to cover my changes <!-- n/a: this is a fix to test infrastructure -->
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Verification:

- Full suite under `-n auto`: **278 passed, 2 skipped, 1 xfailed**; example notebooks (2) and doctests (18)
  pass separately.
- Deleted `lightning_logs/` and re-ran — it is **not recreated** in the repository root, confirming the
  isolation takes effect. That directory had accumulated 1000+ gitignored `version_*` dirs from prior runs.

Two things worth reviewer attention:

- **Doctests are outside this fixture's scope** — they load the root `conftest.py`, not `tests/conftest.py`.
  Safe today: every `>>>` line only constructs forecasters, none call `.fit()`. If a doctest ever fits a
  model, the fixture should move to the root conftest.
- **The chdir is global to the test suite.** Verified safe: `test_examples.py` resolves notebooks via
  `Path(__file__).parent.parent`, and the examples themselves have no relative-path I/O.
