### PR TITLE
chore: update from template v0.28.3 to v0.28.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: c3f6fcf8b6f2ce00e96ae5b918cff755cda0a545
+_commit: d6d0e8260d71339ffe46610d42b2ee4e5061ca93
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 git clone <repo-url>
 cd <project-dir>
 uv sync --group dev
-uv run prek install
+uv run prek install -f
 just test-fast
 ```
 

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -39,7 +39,7 @@ uv sync --group dev
 4. Install the git hooks (required):
 
 ```bash
-uv run prek install
+uv run prek install -f
 ```
 
 ## Development Workflow

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests and doctests with parallel execution
 test:


### PR DESCRIPTION
Updates the project from template **v0.28.3** to **v0.28.4**
(`d6d0e8260d71339ffe46610d42b2ee4e5061ca93`).

Changes `uv run prek install` to `uv run prek install -f` in three places. Without
`-f`, prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy` and
**chains** it — both hooks then run on every commit. `-f` overwrites instead. Since
`just install` is the command people already run, the routine path becomes
self-healing.

Docs-and-tooling only: no code, no config, no changes to the API discovery layer.

## What changed

Exactly 3 files, each carrying the template change and nothing else (verified by
whole-file diff against the pre-update baseline, not by reading the update's own hunks):

| file | change |
|---|---|
| `justfile` | `-f` plus a 4-line comment explaining why |
| `CONTRIBUTING.md` | `-f` |
| `docs/pages/how-to/contribute.md` | `-f` |

Every `prek install` occurrence in the repo was then swept: all three invocations carry
`-f`. The one remaining hit without it is prose in `.pre-commit-config.yaml` describing
what `prek install` wires up — not a command, correctly untouched.

## The local customisation survived

`docs/pages/how-to/contribute.md` is the one file of the three that has **local drift**:
a 4-line frontmatter `description` block this repo added and the template does not ship.
That is exactly the shape a rejected hunk destroys silently, so it was checked
explicitly rather than assumed.

It survived: the file is still 731 lines, the frontmatter is byte-identical, and the
rendered page still emits
`<meta content="Set up a development environment, follow the coding standards, and get a
pull request merged.">`. `justfile` and `CONTRIBUTING.md` were confirmed byte-identical
to a pristine render beforehand, so there was no local content at risk in those.

The update applied with **no `U` states in `git status --porcelain` and no `.rej` files**
anywhere.

## Verification

- API symbol set: **18 → 18** against the pre-Griffe v0.28.1 baseline. LOST / GAINED /
  MOVED / KIND CHANGED all none; `BaseNixtlaForecaster` still at
  `yohou_nixtla.BaseNixtlaForecaster`. `docs/_api_pages.py` and `docs/hooks.py` are
  untouched by this release and remain byte-identical to a pristine render.
- `nox -s check_docs` — **passes, 0 warnings.** No `api: … could not be resolved` lines.
- API index table: **18 rows**, including `BaseNixtlaForecaster`. Hooks log
  `generated 18 API member pages`.
- `git diff --stat -- docs/assets` — **empty**. All 7 files confirmed unchanged by
  sha256. This repo's restored logos are untouched.
- See Also: 40 entries, 39 linked, 1 unlinked (`yohou.point.BasePointForecaster`) —
  unchanged from the previous release and previously verified pre-existing against the
  baseline commit.
- Rendered output confirms the change ships: the built `contribute` page contains
  `uv run prek install -f`.
- `prek run --all-files` — all hooks pass.
