### PR TITLE
chore(template): sync to v0.35.0

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -67,6 +67,7 @@ renovate.json
 .github/ISSUE_TEMPLATE/config.yml
 .github/ISSUE_TEMPLATE/feature_request.yml
 .github/PULL_REQUEST_TEMPLATE.md
+SECURITY.md
 .claude/skills/**                   # Skill files managed by template (the tracked copy)
 .github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
                                     # update never delivers it -- copier works through
@@ -89,12 +90,16 @@ justfile
 docs/index.md
 docs/pages/reference/api.md
 docs/pages/how-to/contribute.md
+docs/pages/explanation/security.md
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions
 .github/workflows/commit-message.yml   # conditional: include_actions
+.github/workflows/codeql.yml       # conditional: include_actions + public repo_visibility
+.github/workflows/scorecard.yml    # conditional: include_actions + public repo_visibility
+CODEOWNERS
 ```
 
 ---

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 8dd0779e406f8abe2bdc740ce2f2fe8adbfa1031
+_commit: e748f5c10c0fdd611bbbdae3783c130a82da87bd
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,13 +1,15 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 96769caeb3394e1e3e13a8cde94b3caf5a92b277
+_commit: 8dd0779e406f8abe2bdc740ce2f2fe8adbfa1031
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin
+code_owner: '@gtauzin'
 description: A Nixtla integration for Yohou
 github_username: stateful-y
 include_actions: True
+include_codecov: True
 include_examples: True
 license: Apache-2.0
 max_python_version: '3.13'
@@ -16,4 +18,5 @@ package_name: yohou_nixtla
 project_name: Yohou-Nixtla
 project_slug: yohou-nixtla
 renovate_preset: 'stateful-y/renovate-config'
+repo_visibility: public
 uv_version: '0.10.0'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,20 +1,30 @@
-name: Build and create changelog PR
+name: Create changelog PR
 
 on:
   push:
     tags:
       - 'v*.*.*'
 
-env:
-  dists-artifact-name: python-package-distributions
+# Least-privilege default: read-only token unless a job widens it explicitly. The PR
+# is opened with a GitHub App token (below), not GITHUB_TOKEN, so no job needs write.
+permissions:
+  contents: read
 
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      # Mint a short-lived, scoped token from the fleet automation GitHub App. A PR
+      # opened with the default GITHUB_TOKEN does not trigger CI or the label-gated
+      # publish, so the automation needs a distinct identity; the App token gives it
+      # one without a long-lived personal access token.
+      - name: Generate a token from the fleet automation GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -69,7 +79,7 @@ jobs:
       - name: Create Pull Request for CHANGELOG
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.CHANGELOG_AUTOMATION_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: |
             CHANGELOG.md
           commit-message: "chore(release): update CHANGELOG.md for ${{ steps.changelog.outputs.version }}"
@@ -89,35 +99,3 @@ jobs:
           labels: |
             changelog
             automated
-
-  build:
-    runs-on: ubuntu-latest
-    needs:
-      - changelog
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "0.10.0"
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build package
-        run: uv build --python 3.11 --python-preference only-managed --sdist --wheel . --out-dir dist
-
-      - name: Check distributions
-        run: uvx twine check dist/*
-
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.dists-artifact-name }}
-          path: dist/*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly-disclosed query pattern still runs against unchanged code.
+    - cron: "27 3 * * 1"
+
+# Least-privilege default: read-only token; the analyze job widens as needed.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload CodeQL results to the Security tab.
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
 
+# Least-privilege default: read-only token.
+permissions:
+  contents: read
+
 jobs:
   validate-commit-message:
     name: Validate Commit Message

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,10 @@ on:
     - cron: "30 2 * * *"
   workflow_dispatch: # Allow manual triggering
 
+# Least-privilege default: read-only token; create-issue-on-failure widens to issues:write.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
 
+# Least-privilege default: read-only token; the job below widens to pull-requests:read.
+permissions:
+  contents: read
+
 jobs:
   validate-pr-title:
     name: Validate PR Title

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,23 +6,26 @@ on:
     branches:
       - main
 
+# Least-privilege default: read-only token unless a job widens it explicitly.
+permissions:
+  contents: read
+
 env:
   dists-artifact-name: python-package-distributions
+  sbom-artifact-name: sbom
 
 jobs:
-  create-release:
+  # Build at the release tag, so hatch-vcs resolves the exact version, and hand the
+  # artifacts to the release/publish jobs natively within this one workflow run. The
+  # build previously lived in changelog.yml and was fetched across workflows with a
+  # third-party action; keeping it here removes that third party from the release path.
+  build:
     # Only run if PR was merged and has the changelog label
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'changelog')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      version: ${{ steps.find_tag.outputs.version }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: main
-
       - name: Find release tag
         id: find_tag
         run: |
@@ -37,20 +40,70 @@ jobs:
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Checkout the release tag
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.find_tag.outputs.version }}
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.10.0"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Build package
+        run: uv build --python 3.11 --python-preference only-managed --sdist --wheel . --out-dir dist
+
+      - name: Check distributions
+        run: uvx twine check dist/*
+
+      # Software bill of materials (CycloneDX) for the release, generated from the
+      # locked dependency set so it enumerates exactly what this release resolves.
+      - name: Generate SBOM (CycloneDX)
+        run: |
+          uv export --frozen --no-emit-project --format requirements-txt -o sbom-requirements.txt
+          uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
+            --output-format JSON --outfile sbom.cdx.json
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.dists-artifact-name }}
+          path: dist/*
+
+      - name: Store the SBOM
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.sbom-artifact-name }}
+          path: sbom.cdx.json
+
+  create-release:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Check out main (not the tag): main carries the CHANGELOG entry the merged
+      # changelog PR just added, which the tag does not yet have.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+
       - name: Extract release notes from CHANGELOG
         id: release_notes
         run: |
-          VERSION="${{ steps.find_tag.outputs.version }}"
+          VERSION="${{ needs.build.outputs.version }}"
           # Strip the 'v' prefix for CHANGELOG lookup (e.g., v0.4.0 -> 0.4.0)
           VERSION_NO_V="${VERSION#v}"
 
-          # Debug: Show what we're working with
-          echo "Looking for version: $VERSION_NO_V (from tag: $VERSION)"
-          echo "First 100 lines of CHANGELOG.md:"
-          head -n 100 CHANGELOG.md
-
           # Extract the section for this version from CHANGELOG.md
-          # This uses awk to get content between the version header and the next version header
           RELEASE_NOTES=$(awk -v ver="$VERSION_NO_V" '
             /^## \[.*\]/ {
               if (found) exit;
@@ -73,27 +126,32 @@ jobs:
           echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Download release artifacts
-        uses: dawidd6/action-download-artifact@v21
+      - name: Download the distribution packages
+        uses: actions/download-artifact@v7
         with:
-          workflow: changelog.yml
           name: ${{ env.dists-artifact-name }}
           path: dist/
-          search_artifacts: true
+
+      - name: Download the SBOM
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ env.sbom-artifact-name }}
+          path: sbom/
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ steps.find_tag.outputs.version }}"
+          VERSION="${{ needs.build.outputs.version }}"
           gh release create "$VERSION" \
             --title "$VERSION" \
             --notes "${{ steps.release_notes.outputs.notes }}" \
-            dist/*
+            dist/* sbom/sbom.cdx.json
 
   pypi-publish:
     name: Publish to PyPI
     needs:
+      - build
       - create-release
     runs-on: ubuntu-latest
     environment:
@@ -102,37 +160,15 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - name: Download the distribution packages
+        uses: actions/download-artifact@v7
         with:
-          fetch-depth: 0
-          ref: main
-
-      - name: Find release tag
-        id: find_tag
-        run: |
-          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
-
-          if [ -z "$VERSION" ]; then
-            echo "No version found in PR title"
-            exit 1
-          fi
-
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Download release artifacts
-        uses: dawidd6/action-download-artifact@v21
-        with:
-          workflow: changelog.yml
           name: ${{ env.dists-artifact-name }}
           path: dist/
-          search_artifacts: true
-          workflow_conclusion: success
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # renovate: datasource=github-releases depName=pypa/gh-action-pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true
           verify-metadata: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly independent grade of the repo's security posture.
+    - cron: "21 4 * * 2"
+  push:
+    branches: [main]
+
+# Least-privilege default: read-only token; the analysis job widens as needed.
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the results to the Security tab and publish to the OpenSSF API.
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ github.token }}
+          # Publish results to the OpenSSF Scorecard API (public repos only).
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+# Least-privilege default: read-only token. No job here writes.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -340,6 +344,29 @@ jobs:
         run: nox -s test_examples
 
 
+  # Secret scanning. Runs the gitleaks binary directly (not gitleaks-action, which
+  # requires a paid license for private org repos) so it works identically on public
+  # and private repos. This is the CI backstop to the pre-commit gitleaks hook: it
+  # cannot be bypassed with --no-verify, and it is a dependency of the ci-passed
+  # roll-up below, so a detected secret fails the single required merge check.
+  secret-scan:
+    name: Secret scanning (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          # renovate: datasource=github-releases depName=gitleaks/gitleaks
+          GITLEAKS_VERSION=8.24.3
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Scan for secrets
+        run: gitleaks detect --source . --redact --verbose
+
   # Single required status check. The branch ruleset requires this one job, not the
   # individual jobs above: test-fast is a matrix (its check-run names vary by OS/Python and
   # differ between draft and ready PRs) and test-full is skipped on draft PRs, so neither
@@ -361,6 +388,7 @@ jobs:
       - lint
       - test_docstrings
       - check_docs
+      - secret-scan
       - examples
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,15 @@ repos:
         stages: [commit-msg]
 
 
+  # Secret scanning: block secrets before they enter history. prek runs the official
+  # gitleaks hook (its golang language is supported). The gitleaks CI job is the
+  # un-bypassable backstop; this hook is the earliest catch, so it stays at pre-commit
+  # even though the refusing whole-project hooks (ty) run at pre-push.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks
+
   # Version-sensitive linters run from the project environment so their single
   # source of truth is uv.lock. --locked makes a stale uv.lock fail loudly
   # instead of silently diverging from CI. (Dependabot's "uv" ecosystem then

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for Yohou-Nixtla.
+#
+# Each line maps a path pattern to the owner(s) requested for review on changes.
+# `code_owner` is a GitHub username (@user) or a team (@org/team); a bare
+# organization name is not a valid code owner.
+* @gtauzin

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest published version of Yohou-Nixtla.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately through GitHub's
+[private vulnerability reporting](https://github.com/stateful-y/yohou-nixtla/security/advisories/new)
+rather than opening a public issue.
+
+We aim to acknowledge a report within a few working days and will keep you updated as
+we investigate and prepare a fix. Please give us a reasonable window to release a patch
+before any public disclosure.

--- a/docs/pages/explanation/security.md
+++ b/docs/pages/explanation/security.md
@@ -1,0 +1,66 @@
+# Security
+
+Yohou-Nixtla is built on a hardened, security-first release pipeline. This page
+explains the measures that protect you as a *user* of the package and what each one means
+in practice, so you can depend on it with confidence.
+
+## How releases reach you safely
+
+**Trusted publishing (OIDC).** Releases are published to PyPI through GitHub's OpenID
+Connect trusted-publishing flow. No long-lived PyPI API token exists anywhere to be stolen
+and used to push a malicious release: a release can only originate from this project's own
+audited release workflow.
+
+**Signed artifacts (PEP 740 attestations).** Every published distribution carries a
+cryptographic attestation, produced with Sigstore, binding the artifact to the exact
+workflow run that built it. You can verify that what you install is what this project
+actually released, not a tampered copy.
+
+**A software bill of materials (SBOM).** Each release ships a CycloneDX SBOM enumerating
+every dependency it resolves. When a vulnerability is disclosed in a transitive
+dependency, you can tell in seconds whether a given release is affected.
+
+**Immutable, monitored dependencies.** Third-party GitHub Actions and Python dependencies
+are pinned, and Renovate keeps them current as reviewable pull requests. A dependency
+cannot be swapped out from under a release, and updates arrive as visible changes rather
+than silent drift.
+
+## How the code is checked
+
+**Static security analysis.** Every change is scanned with ruff's flake8-bandit (`S`)
+ruleset, which flags insecure patterns (unsafe subprocess use, weak hashing, hardcoded
+credentials, unsafe deserialization) before they can merge.
+
+**Deep analysis (CodeQL).** GitHub's CodeQL runs data-flow analysis on every change and on
+a weekly schedule, catching vulnerability classes such as injection and path traversal that
+line-level linting cannot see.
+
+**Secret scanning.** gitleaks runs both as a pre-commit hook and as a CI check that cannot
+be bypassed, so credentials and keys never enter the codebase or a release.
+
+## How the pipeline itself is hardened
+
+**Least privilege.** Every automation workflow runs with a read-only token by default;
+only the specific jobs that must write are granted more. A compromised step cannot quietly
+rewrite the repository.
+
+**A single merge gate.** No change lands on the main branch until the full test suite and
+the security checks above all pass, enforced as one required status check.
+
+**Scoped automation identity.** Release automation authenticates with a short-lived,
+narrowly-scoped GitHub App token rather than a broad personal access token, so there is no
+long-lived automation credential to leak.
+
+## Transparency and disclosure
+
+**An independent security grade.** This repository is scored weekly by the
+[OpenSSF Scorecard](https://securityscorecards.dev/), an external automated audit of its
+security practices (pinned dependencies, token permissions, branch protection, and more).
+The result is public, so the posture is verifiable rather than merely asserted.
+
+**Responsible disclosure.** If you find a vulnerability, the
+[security policy](https://github.com/stateful-y/yohou-nixtla/security/policy)
+explains how to report it privately, before any public disclosure.
+
+**Reviewed changes.** Code ownership is declared in `CODEOWNERS`, so changes are reviewed
+before they merge.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -246,6 +246,7 @@ nav:
   - Explanation:
     - pages/explanation/index.md
     - Concepts: pages/explanation/concepts.md
+    - Security: pages/explanation/security.md
   # Reference is last on purpose: it is the section you arrive at knowing what
   # you want, so it earns its place by being findable, not by being passed
   # through. Everything above it is read in roughly the order a newcomer needs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["ARG", "S101", "S110", "S301", "S311", "S603", "S607", "T201", "PLR2004"]  # Allow asserts, try/except/pass, pickle, non-crypto random, subprocess, prints, and magic values in tests
+"tests/**/*" = ["ARG", "S101", "S104", "S105", "S106", "S107", "S108", "S110", "S112", "S301", "S311", "S603", "S607", "T201", "PLR2004"]  # Insecure-looking patterns that are legitimate in tests: asserts; bind-all-interfaces; hardcoded passwords/temp paths; try/except pass/continue; pickle; non-crypto random; subprocess; prints; magic values
 # The template's documentation build tooling lives in docs_build/. Every script
 # there prints build progress and may hold per-build caches.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ select = [
     "ARG", # flake8-unused-arguments
     "SIM", # flake8-simplify
     "PL",  # Pylint
+    "S",   # flake8-bandit (security)
     "T10", # flake8-debugger
     "T201", # Print statement
 ]
@@ -195,18 +196,18 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["ARG", "S101", "T201", "PLR2004"]  # Allow assert statements, prints, and magic values in tests
+"tests/**/*" = ["ARG", "S101", "S110", "S301", "S311", "S603", "S607", "T201", "PLR2004"]  # Allow asserts, try/except/pass, pickle, non-crypto random, subprocess, prints, and magic values in tests
 # The template's documentation build tooling lives in docs_build/. Every script
 # there prints build progress and may hold per-build caches.
 #
 # Deliberately `docs_build/*.py`, NOT `docs_build/_*.py`: the narrower glob would
 # silently drop coverage for any un-underscored script, which is the failure
 # shape this fleet specialises in. The pattern matches what the directory is for.
-"docs_build/*.py" = ["T201", "PLW0603"]  # Allow prints and per-build cache globals in every build script
+"docs_build/*.py" = ["T201", "PLW0603", "S506", "S603", "S112"]  # Build tooling: prints, per-build cache globals, mkdocs.yml full-loader, subprocess to run notebooks, and skip-on-error loops over controlled input
 # `docs/*.py` is kept too, for a project's OWN scripts under docs/ (yohou has
 # docs/precache_datasets.py) -- the template ships none there any more, but a
 # project script prints progress the same way and should not lose its exemption.
-"docs/*.py" = ["T201", "PLW0603"]
+"docs/*.py" = ["T201", "PLW0603", "S506", "S603", "S112"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["yohou_nixtla"]

--- a/src/yohou_nixtla/_base.py
+++ b/src/yohou_nixtla/_base.py
@@ -325,7 +325,7 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
         X_wide = dict_to_panel(X_t)
 
         # 3. Store original column names for reconstruction
-        assert y_wide is not None, "y_wide must not be None after _pre_fit"
+        assert y_wide is not None, "y_wide must not be None after _pre_fit"  # noqa: S101  # type-narrowing for the type checker
         self.y_columns_ = [c for c in y_wide.columns if c != "time"]
 
         # 4. Infer frequency
@@ -516,8 +516,8 @@ class BaseNixtlaForecaster(BaseClassWrapper, BasePointForecaster, metaclass=abc.
             return pl.concat([y_pred_inv.select("time"), value_cols], how="horizontal")
 
         # Panel data: per-group inverse transform
-        assert isinstance(self.target_transformer_, dict)
-        assert isinstance(self._y_observed, dict)
+        assert isinstance(self.target_transformer_, dict)  # noqa: S101  # type-narrowing for the type checker
+        assert isinstance(self._y_observed, dict)  # noqa: S101  # type-narrowing for the type checker
         inv_parts: list[pl.DataFrame] = []
         for group_name in self.groups_:
             group_cols = [c for c in y_pred.columns if c.startswith(f"{group_name}__")]


### PR DESCRIPTION
Syncs the project to template **v0.34.0** (bundles two template releases).

## v0.33.0 — fleet security hardening
- Top-level `permissions: contents: read` on all templated workflows.
- ruff `S` (flake8-bandit) enabled in `pyproject.toml`.
- gitleaks pre-commit hook (`gitleaks/gitleaks@v8.24.3`) + `secret-scan` CI job wired into `ci-passed` `needs:` in `tests.yml`.
- `changelog.yml` migrated to `create-github-app-token`; build/upload jobs removed.
- `publish-release.yml` restructured: native upload/download-artifact, CycloneDX SBOM, `pypa/gh-action-pypi-publish@v1.13.0` pinned, `dawidd6` removed.
- New: `.github/workflows/codeql.yml`, `.github/workflows/scorecard.yml`, `SECURITY.md`, `CODEOWNERS` (`* @gtauzin`).

## v0.34.0 — security posture page
- New `docs/pages/explanation/security.md` + `Security` nav entry under Explanation.
- `tests/**` ruff ignore gains S301/S110/S311 (also S603/S607).

## Local resolution
- New copier answers: `repo_visibility=public`, `include_codecov=true`, `code_owner=@gtauzin`.
- mkdocs nav merged cleanly — Explanation 2 → 3 leaves (Security added), all curated content preserved.
- ruff `S` triage: 3 S101 type-narrowing asserts in `src/yohou_nixtla/_base.py` given targeted `# noqa: S101`.
- `docs/assets/` untouched.

## Verification
- `nox -s check_docs`: strict build, 0 warnings, security page builds and appears in nav.
- `nox -s test_fast`: 238 passed / 2 skipped across 3.11 / 3.12 / 3.13.
- `ruff check .` clean; all prek hooks pass.

---
**Held for review; do not merge.**