### PR TITLE
chore(template): sync to v0.37.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 804bc6947a8671392eb93470bb7fe0b8874722ee
+_commit: 3b9107a65f86f0e52e8a03fd704b033ccdbcf7a2
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -698,12 +698,22 @@ graph LR
 
 ### How It Works
 
-1. **Tag a release:**
+1. **Tag a release** (signed with [gitsign](https://github.com/sigstore/gitsign) keyless Sigstore signing):
 
     ```bash
-   git tag v0.2.0 -m "Release v0.2.0"
+   git tag -s v0.2.0 -m "Release v0.2.0"
    git push origin v0.2.0
     ```
+
+    One-time gitsign setup so `git tag -s` signs via Sigstore, with no long-lived GPG key to manage:
+
+    ```bash
+   git config --local gpg.x509.program gitsign
+   git config --local gpg.format x509
+   git config --local tag.gpgSign true
+    ```
+
+    The first signing authenticates via your identity provider in a browser; verify a tag with `gitsign verify-tag`. Signed tags complement the PEP 740 artifact attestations the publish workflow already produces, so both the tag and the published artifacts are verifiable.
 
 2. **Automated changelog workflow** (`changelog.yml`):
     - Generates changelog from conventional commits using git-cliff


### PR DESCRIPTION
Syncs yohou-nixtla to python-package-copier **v0.37.0**.

## What changed

Docs-only delta. The single template change adds a **gitsign tag-signing** section to `docs/pages/how-to/contribute.md`:

- Release Process now uses `git tag -s` (signed) instead of `git tag`.
- Adds a one-time gitsign config block (keyless Sigstore signing, no long-lived GPG key).
- Notes signed tags complement the PEP 740 artifact attestations the publish workflow already produces.

## Files touched

- `.copier-answers.yml` — `_commit` bumped to v0.37.0
- `docs/pages/how-to/contribute.md` — gitsign section added

No nav / workflow / config changes. `docs/assets` untouched.

## Verification

- `uvx copier update --vcs-ref v0.37.0 --trust --defaults` — clean, no `.rej`, no merge conflicts
- `uvx nox -s check_docs` — build finished, **No issues found** (0 warnings)
- `prek run --all-files` — all hooks passed

---

Held for review; do not merge.
