### PR TITLE
chore: update from template v0.39.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 80ca9f8f495a141f90bb5ff7b980c5b25d63a922
+_commit: 9bbf88ac3171f6296c91fcfdd3c3ef31ea6986f3
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin
@@ -19,4 +19,3 @@ project_name: Yohou-Nixtla
 project_slug: yohou-nixtla
 renovate_preset: 'stateful-y/renovate-config'
 repo_visibility: public
-uv_version: '0.10.0'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,8 +7,12 @@ on:
 
 # Least-privilege default: read-only token unless a job widens it explicitly. The PR
 # is opened with a GitHub App token (below), not GITHUB_TOKEN, so no job needs write.
+# `pull-requests: read` is for git-cliff, which reads merged PRs to attribute entries;
+# it stays on GITHUB_TOKEN rather than borrowing the App token, whose write scope this
+# job needs only for opening the PR.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changelog:
@@ -38,6 +42,15 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          # `.git-cliff.toml` sets `[remote.github]`, so git-cliff calls the GitHub API
+          # to attach PR links and @usernames to each entry. Without a token those calls
+          # are anonymous, and anonymous means 60 requests/hour shared across every job
+          # on the runner's IP -- so this step used to succeed or 403 depending on who
+          # else was building at the time. git-cliff panics on that 403 (exit 101) rather
+          # than falling back to plain entries, which turned a rate limit into a failed
+          # release. Authenticated, the ceiling is 5000/hour and the flake goes away.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get the tag name
           TAG_NAME="${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -59,15 +59,17 @@ jobs:
         run: uv build --python 3.11 --python-preference only-managed --sdist --wheel . --out-dir dist
 
       - name: Check distributions
-        run: uvx twine check dist/*
+        # renovate: datasource=pypi depName=twine
+        run: uvx twine==7.0.0 check dist/*
 
       # Software bill of materials (CycloneDX) for the release, generated from the
       # locked dependency set so it enumerates exactly what this release resolves.
       - name: Generate SBOM (CycloneDX)
+        # renovate: datasource=pypi depName=cyclonedx-bom
         run: |
           uv export --frozen --no-emit-project --format requirements-txt -o sbom-requirements.txt
-          uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
-            --output-format JSON --outfile sbom.cdx.json
+          uvx --from cyclonedx-bom==7.3.1 cyclonedx-py requirements sbom-requirements.txt \
+            --output-format JSON --output-file sbom.cdx.json
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@v7
@@ -138,12 +140,17 @@ jobs:
           name: ${{ env.sbom-artifact-name }}
           path: sbom/
 
-      - name: Create GitHub Release
+      # Created as a draft: a draft release is visible to maintainers only, so nothing
+      # is public until the `pypi` environment gate has been approved and the upload
+      # has succeeded. `finalize-release` undrafts it. If the gate is rejected or the
+      # upload fails, the draft is all that exists and can simply be deleted.
+      - name: Create draft GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           gh release create "$VERSION" \
+            --draft \
             --title "$VERSION" \
             --notes "${{ steps.release_notes.outputs.notes }}" \
             dist/* sbom/sbom.cdx.json
@@ -172,3 +179,20 @@ jobs:
         with:
           attestations: true
           verify-metadata: false
+
+  # Last step in the chain: make the release public only once the artifacts are
+  # actually on PyPI, so the GitHub Release and the PyPI record cannot disagree.
+  finalize-release:
+    name: Publish the GitHub Release
+    needs:
+      - build
+      - pypi-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Undraft the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release edit "${{ needs.build.outputs.version }}" --draft=false


### PR DESCRIPTION
Template v0.39.0. **Held for review — do not merge without checking the diff.**

Three release-path defects, all found by cutting one real release in `sklearn-wrap`, all previously shipped here:

| | what was broken | what changes |
|---|---|---|
| #256 | git-cliff's GitHub API calls were anonymous (60/hr, shared per runner IP). It panics on the resulting 403 instead of degrading, so the job exits 101, no changelog PR opens, and a pushed tag is left with no release behind it. | `GITHUB_TOKEN` on the generate step, `pull-requests: read` on the job. |
| #258 | The SBOM step passed `--outfile`, **removed in cyclonedx-bom 7.x**, and invoked the tool unpinned — so it broke on the day 7.0 shipped, with no change in this repo. Your next release would have failed at that step. | `--output-file`, plus exact pins for `cyclonedx-bom` and `twine`, each with a `# renovate:` annotation. |
| #259 | The `pypi` approval gate sat on the last job, so a **public GitHub Release with all artifacts was published before the approval was requested**. Rejecting cost more than approving. | The release is created `--draft`; a new `finalize-release` job undrafts it only after the PyPI upload succeeds. |

`.copier-answers.yml` also loses `uv_version`: uv is a template literal now, maintained by Renovate like `nox` and `git-cliff`, rather than a per-project answer that would have gone stale the moment Renovate advanced the real pin.

## Verification

```
copier update            exit 0
conflict-marker sweep    none      (^(<<<<<<<|>>>>>>>|=======)( |$))
.rej sweep               none
git status --porcelain   3 modified, no U states
git diff docs/assets     empty
```

Every changed file was diffed **whole-file** against its pre-update state, not just inspected for the update's own hunks. The result was also compared against a pristine v0.39.0 render at this repo's own answers.

**No `version:` pin changed in any workflow** — that is the invariant for the `uv_version` demotion, which was done at the current value so the only intended effect is one line leaving the answers file.

## Not verified locally

`nox -s check_docs` was not run. Diffing pristine renders across v0.38.0→v0.39.0 shows exactly three changed files, none of them docs, so a local docs build would have tested nothing about this change. This PR's CI runs it.

Lint was left to this PR's `Lint and format` job rather than a local `prek` pass, since the edits are two workflow files and a copier-generated answers file.
