### PR TITLE
chore: update from template v0.40.1

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -99,6 +99,9 @@ docs/pages/explanation/security.md
 .github/workflows/commit-message.yml   # conditional: include_actions
 .github/workflows/codeql.yml       # conditional: include_actions + public repo_visibility
 .github/workflows/scorecard.yml    # conditional: include_actions + public repo_visibility
+.github/codeql/codeql-config.yml   # conditional: include_actions + public repo_visibility.
+                                   # Scopes the CodeQL scan; a project may add its own
+                                   # exclusions, so merge rather than overwrite.
 CODEOWNERS
 ```
 

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: e61fdc1b9d718318344f6e9b2406b92810f12b08
+_commit: c1343c6c8cf8ac01e92a81e7565e26590319af02
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+# CodeQL scans the package, not the harness that exercises it.
+#
+# Without this file, `init` runs the default query suite over the whole checkout. The
+# security queries then read test assertions and example notebooks as if they were
+# production code paths, and report on them: `py/incomplete-url-substring-sanitization`
+# fires on `assert "docs.python.org" in url` (an assertion that config content is
+# present, not a trust decision), and `py/clear-text-logging-sensitive-data` fires on any
+# variable whose name contains "secret" or "trusted" -- including an allowlist of public
+# package names printed by an example.
+#
+# Every such alert is a false positive, and dismissing them one by one does not hold:
+# the shapes recur every time a test asserts on a URL. Excluding the directories is the
+# fix that stays fixed.
+#
+# The cost is real and deliberate: CodeQL no longer analyses test or example code. That
+# code does not run in production, has no untrusted input, and is already covered by
+# ruff's flake8-bandit (`S`) ruleset, which runs over the whole repository on every
+# change. `src/` and `docs_build/` -- the code that ships and the code that builds the
+# site -- stay in scope.
+name: "yohou_nixtla (source only)"
+
+paths-ignore:
+  - tests
+  - examples

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,10 @@ jobs:
         uses: github/codeql-action/init@a2983b8bed1923f44751c5c43237f479442827b3 # v3
         with:
           languages: python
+          # Scopes the scan to shipped code. Without it the default suite reads test
+          # assertions and example notebooks as production code paths; see the config
+          # file for which queries that trips and why excluding beats dismissing.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@a2983b8bed1923f44751c5c43237f479442827b3 # v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,10 +28,15 @@ jobs:
     steps:
       - name: Find release tag
         id: find_tag
+        # The PR title reaches the shell through the environment, never through
+        # an expression inside `run:`. An expression is substituted into the
+        # script before bash parses it, so a title carrying shell metacharacters
+        # would execute here -- in a job that goes on to publish. An env var is data.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
+          VERSION=$(printf '%s' "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"
@@ -179,7 +184,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        # renovate: datasource=github-releases depName=pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/docs/pages/explanation/security.md
+++ b/docs/pages/explanation/security.md
@@ -47,6 +47,14 @@ rewrite the repository.
 **A single merge gate.** No change lands on the main branch until the full test suite and
 the security checks above all pass, enforced as one required status check.
 
+**Untrusted input never becomes code.** Values an outsider controls -- a pull request
+title, an issue body, a fork's branch name -- reach a workflow's shell only as environment
+variables. Workflow expressions are substituted into a script *before* the shell parses
+it, so interpolating one directly turns a crafted pull request title into commands that
+run with the release job's privileges. Quoting does not help; passing the value through
+`env:` does, because the runner then hands it over as data. A test asserts no workflow
+interpolates such a value into a `run:` or `script:` body.
+
 **Scoped automation identity.** Release automation authenticates with a short-lived,
 narrowly-scoped GitHub App token rather than a broad personal access token, so there is no
 long-lived automation credential to leak.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,12 +89,18 @@ docs = [
     # package. `mkdocs`/`mkdocs-material` above are kept so CI can still run a
     # MkDocs build as a comparison during the engine transition.
     "zensical>=0.0.51",
-    # Floor matches Zensical's own requirement (pymdown-extensions>=10.21.3).
-    # Do NOT pin to >=11: the examples group's notebook runtime caps
-    # pymdown-extensions at <11, so a project with examples must resolve it in
-    # [10.21.3, 11). Zensical works with either major; forcing 11 makes the
-    # docs-plus-examples sync unsatisfiable.
-    "pymdown-extensions>=10.21.3",
+    # Floor is a security floor: 10.x carries a path traversal in the b64 extension
+    # (GHSA-9xwg-3r6f-jcx2, fixed in 11.0.0) and 11.0.0 carries a ReDoS in four inline
+    # processors (GHSA-gm37-52c6-37mw, fixed in 11.0.1). Zensical works with either
+    # major, so nothing here argues for staying on 10.
+    #
+    # This floor used to read >=10.21.3 with a comment forbidding >=11, because the
+    # examples group's notebook runtime capped it at <11 and a project with examples
+    # could not resolve otherwise. That is what let a known-vulnerable version sit in
+    # five repositories: the cap was real, the CVEs landed behind it, and nothing
+    # rechecked the cap afterwards. That runtime has since relaxed its cap, and the
+    # examples group floors at the first release that did -- the two must move together.
+    "pymdown-extensions>=11.0.1",
     # Also a direct import of docs_build/_api_pages.py, which reads mkdocstrings'
     # `preload_modules` out of mkdocs.yml so that list has one definition rather
     # than two. Same argument as griffe above: it arrives via mkdocs anyway, but
@@ -116,7 +122,11 @@ fix = [
   "prek>=0.4.10",
 ]
 examples = [
-    "marimo>=0.19.0",
+    # Floor is set by the docs group, not by anything marimo does. marimo caps
+    # pymdown-extensions, and every release before 0.23.16 capped it at <11 -- below
+    # the version that fixes two published advisories. Lowering this floor puts those
+    # CVEs back in the lockfile of every project that generates examples.
+    "marimo>=0.23.16",
     "plotly>=5.19",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
     { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
     { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
     { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
     { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
     { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
@@ -671,7 +673,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
     { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
     { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
     { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
     { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
     { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
     { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
@@ -679,7 +683,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -966,7 +972,7 @@ wheels = [
 
 [[package]]
 name = "marimo"
-version = "0.23.14"
+version = "0.23.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "sys_platform != 'emscripten'" },
@@ -986,12 +992,13 @@ dependencies = [
     { name = "pyzmq", marker = "sys_platform != 'emscripten'" },
     { name = "starlette", marker = "sys_platform != 'emscripten'" },
     { name = "tomlkit" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
     { name = "websockets", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/33/b60febb3f7e44658fc0c4b59e04ba9071e01f4186235d9dd1864e7efba72/marimo-0.23.14.tar.gz", hash = "sha256:f33f17abb5106edabf6921d016d91a6d8f02b4d1b0ed599039957b8f7f5b9489", size = 38705304, upload-time = "2026-07-10T20:01:01.646Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/c0/b6b7101dc9d3760c51d67714d4547047cb2c29c11f26691bed6a64d8a995/marimo-0.23.16.tar.gz", hash = "sha256:378c892f0e1bc3985bc0b5b61109078e09fc767438b95234bfec9faa45858c98", size = 38789959, upload-time = "2026-07-31T20:04:47.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/ea/898058b213ed79555cf4fde8f59fcb2c257c888dcbc351e0670d3a0b632d/marimo-0.23.14-py3-none-any.whl", hash = "sha256:c93a25ab3ae928f06d2d9855c8b582836485ad9af4d038de2eac8d028af837ee", size = 39160204, upload-time = "2026-07-10T20:00:58.325Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7a/db0583b21d1f03403fc26800cb4638f59e95a33efd333f7a4d45ac348b82/marimo-0.23.16-py3-none-any.whl", hash = "sha256:e0bba0a44b395d402072c65d686fb459bd8955c9ab8b0d6135a22f729c989373", size = 39241287, upload-time = "2026-07-31T20:04:43.678Z" },
 ]
 
 [[package]]
@@ -2045,15 +2052,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -3231,14 +3238,14 @@ dev = [
     { name = "griffe", specifier = ">=1.0" },
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "interrogate", specifier = ">=1.7.0" },
-    { name = "marimo", specifier = ">=0.19.0" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
     { name = "plotly", specifier = ">=5.19" },
     { name = "prek", specifier = ">=0.4.10" },
-    { name = "pymdown-extensions", specifier = ">=10.21.3" },
+    { name = "pymdown-extensions", specifier = ">=11.0.1" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-mock", specifier = ">=3.14" },
@@ -3253,19 +3260,19 @@ dev = [
 ]
 docs = [
     { name = "griffe", specifier = ">=1.0" },
-    { name = "marimo", specifier = ">=0.19.0" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
     { name = "plotly", specifier = ">=5.19" },
-    { name = "pymdown-extensions", specifier = ">=10.21.3" },
+    { name = "pymdown-extensions", specifier = ">=11.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "watchdog", specifier = ">=4.0" },
     { name = "zensical", specifier = ">=0.0.51" },
 ]
 examples = [
-    { name = "marimo", specifier = ">=0.19.0" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "plotly", specifier = ">=5.19" },
 ]
 fix = [{ name = "prek", specifier = ">=0.4.10" }]


### PR DESCRIPTION
Updates from python-package-copier **v0.40.0 → v0.40.1** (`_commit` `e61fdc1` → `c1343c6`).

**Held for review — please do not merge without a look.**

## What this delivers

**1. Shell-injection fix in `publish-release.yml` (the point of the release).** The
`Find release tag` step took the PR title as a `${{ github.event.pull_request.title }}`
expression *inside* `run:`. Expressions are substituted before bash parses the script, so
a crafted title executed as commands in a job that holds `contents: write` and gates the
PyPI publish. The title now arrives via `env: PR_TITLE:` and is read with `printf '%s'`.

**2. CodeQL scan scoping.** New `.github/codeql/codeql-config.yml`, wired into
`codeql.yml`'s `init` step via `config-file:`. `paths-ignore` lists **`tests` and
`examples`** — this project has `include_examples: True`.

**3. pymdown-extensions and marimo floors, moved together.**
`pymdown-extensions>=10.21.3 → >=11.0.1` and `marimo>=0.19.0 → >=0.23.16`. marimo below
0.23.16 caps pymdown-extensions at `<11`, which is below the fix for
**GHSA-9xwg-3r6f-jcx2** (path traversal in the b64 extension) and
**GHSA-gm37-52c6-37mw** (ReDoS in four inline processors). This repository was on the
vulnerable 10.21.3. `uv.lock` now resolves **pymdown-extensions 11.0.1** and
**marimo 0.23.16**.

This supersedes Dependabot #60, which bumps pymdown-extensions alone and would leave the
marimo cap in place.

**4. `docs/pages/explanation/security.md`** gains the "Untrusted input never becomes code"
paragraph.

**5. Ride-along:** the redundant `# renovate:` annotation above the PyPI publish step is
dropped — Renovate's built-in `github-actions` manager already reads that `uses:` line.

## Digest pins were kept, not un-pinned

Every `uses:` line in this repository is Renovate digest-pinned, while the template ships
tags. All **21 conflict hunks** across seven workflow files were `uses:` lines and were
resolved by **keeping the local digest**; v0.40.1's `@v7 → @v7.0.1` tag moves were
discarded. Resolving toward the template would have un-pinned the repository and reopened
OpenSSF Scorecard's `PinnedDependenciesID` findings.

Verified: all **49** `uses:` refs are byte-identical to the pre-update tree, and all 49
still carry a 40-hex digest. `changelog.yml`, `commit-message.yml`, `nightly.yml`,
`scorecard.yml` and `tests.yml` therefore end up with **zero** net change.

## Verification

- `git diff --stat -- docs/assets` is **empty**, and all 7 asset checksums are unchanged
  (this repository's logos were destroyed by a past copier update).
- No `.rej` files. Eight files came out `UU` with inline markers; all resolved, and a
  repo-wide marker sweep (`^(<<<<<<<|>>>>>>>|=======)( |$)`) is clean.
- `mkdocs.yml` is untouched — no nav clobber this round.
- No workflow interpolates `${{ github.event.* }}` into a `run:` or `script:` body
  (checked by parsing the YAML, not by grep).
- Strict docs build: **"No issues found"**, 0 warnings, 39 pages, 18 API rows including
  the root-only export `BaseNixtlaForecaster`. Measured in a clean container — see below.
- `prek run --all-files`: all 13 hooks pass.

⚠️ The strict docs build is a **no-op on the current host** (0.10s, zero pages emitted,
exit 0) because of inotify-instance exhaustion. It was re-measured inside a
`ghcr.io/astral-sh/uv:python3.13-bookworm-slim` container, where it takes 4.6s and reports
"No issues found"; the same container fails correctly (exit 1) on a deliberately injected
broken link, so the pass is real.
