### PR TITLE
fix(ci): pin the nightly Codecov upload and check every upload, not just one

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 2ef4acdac177596054e95a53c88406f215bc038a
+_commit: 10e9f41542bbcf96855ec8049cb1e0802572a610
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,13 @@ jobs:
         if: ${{ matrix.python-version == '3.12' }}
         with:
           use_oidc: true
+          # Named explicitly, with the uploader's search off. This step had
+          # neither for several releases: it uploaded whatever the fallback happened to
+          # find, which is the exact pattern the tests.yml upload was fixed to remove --
+          # and it survived that fix because the check only looked at tests.yml.
+          files: '${{ github.workspace }}/.artifacts/coverage.xml'
+          disable_search: true
+          fail_ci_if_error: true
 
   # The release path's tools, exercised where a failure is cheap.
   #

--- a/.gitignore
+++ b/.gitignore
@@ -77,11 +77,13 @@ examples/__marimo__/
 # database, which the generated conftest.py points under `.artifacts/`.
 #
 # Recent Hypothesis drops a self-ignoring `.gitignore` inside it, and this entry was
-# removed on the strength of that. It is version-dependent: 6.165.2 writes the file,
-# 6.151.9 does not, and the project floors at `hypothesis>=6.100`. A repo resolving
-# below the cutoff gets ~26 untracked files at its root -- the exact mess the
-# `.artifacts/` layout exists to prevent, reintroduced by trusting a library's
-# internal behaviour across a range it does not promise.
+# removed on the strength of that. It is version-dependent, and the project floors at
+# `hypothesis>=6.100`. Measured across the fleet: 6.151.9 does NOT write the file;
+# 6.156.9, 6.158.0, 6.161.2 and 6.165.2 all do -- so the cutoff sits between 6.151.9
+# and 6.156.9, and every repo measured happened to resolve above it. One did not, and
+# got ~26 untracked files at its root: the exact mess the `.artifacts/` layout exists to
+# prevent, reintroduced by trusting a library's internal behaviour across a range it
+# does not promise. Nothing pins the resolution, so the entry stays.
 .hypothesis/
 
 # Markdown linter cache. rumdl has no cache-path option, so unlike the caches

--- a/tests/test_artifact_paths.py
+++ b/tests/test_artifact_paths.py
@@ -208,36 +208,61 @@ def test_every_reader_of_the_built_site_agrees_with_mkdocs():
         assert site_dir in text, f"{name} reads the built site but not at {site_dir!r} from mkdocs.yml `site_dir`"
 
 
-def test_coverage_upload_names_the_file_coverage_writes():
-    """The Codecov `files:` input must name the file the coverage config produces.
+def _workflows_uploading_coverage():
+    """Every workflow file containing a Codecov upload step.
+
+    Deliberately discovered, not listed. The first version of these checks named
+    `tests.yml` and nothing else, so a second upload in `nightly.yml` -- with no
+    `files:` and no `disable_search:`, relying entirely on the fallback -- sat
+    unnoticed through the release that removed exactly that pattern from `tests.yml`.
+    A check that names its own scope cannot see the instance it was not told about.
+    """
+    workflows = _PROJECT / ".github/workflows"
+    if not workflows.is_dir():
+        return []
+
+    return [
+        path for path in sorted(workflows.glob("*.yml")) if "codecov/codecov-action" in path.read_text(encoding="utf-8")
+    ]
+
+
+def test_a_coverage_upload_exists_to_check():
+    """Guard the input set, so the two checks below cannot pass over nothing."""
+    assert _workflows_uploading_coverage(), (
+        "no workflow uploads coverage, so the assertions about upload paths measure nothing"
+    )
+
+
+def test_every_coverage_upload_names_the_file_coverage_writes():
+    """Each Codecov `files:` input must name the file the coverage config produces.
 
     These drifted apart once before and nothing noticed, because the uploader's
-    fallback search found the real report and reported success.
+    fallback search found the real report and reported success anyway.
     """
     pyproject = (_PROJECT / "pyproject.toml").read_text(encoding="utf-8")
     written = re.search(r"\[tool\.coverage\.xml\][^\[]*?output\s*=\s*\"([^\"]+)\"", pyproject, re.S)
     assert written, "pyproject.toml does not set [tool.coverage.xml] output; the report path is undefined"
 
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-    uploaded = re.search(r"files:\s*'\$\{\{ github\.workspace \}\}/([^']+)'", workflow)
-    assert uploaded, "the coverage upload step does not name a file"
+    for path in _workflows_uploading_coverage():
+        text = path.read_text(encoding="utf-8")
+        uploaded = re.search(r"files:\s*'?\$\{\{ github\.workspace \}\}/([^'\s]+)'?", text)
 
-    assert uploaded.group(1) == written.group(1), (
-        f"coverage upload reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
-    )
+        assert uploaded, f"{path.name} uploads coverage without naming a file, so it relies on the fallback search"
+        assert uploaded.group(1) == written.group(1), (
+            f"{path.name} reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
+        )
 
 
-def test_coverage_upload_does_not_fall_back_to_searching():
+def test_no_coverage_upload_falls_back_to_searching():
     """`fail_ci_if_error` only means something with the uploader's search disabled.
 
     With search on, a `files:` input naming nothing is not an error: the CLI scans
     the workspace, uploads whatever it finds, and the step passes.
     """
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-
-    assert "disable_search: true" in workflow, (
-        "the coverage upload leaves search enabled, so a wrong `files:` path cannot fail the build"
-    )
+    for path in _workflows_uploading_coverage():
+        assert "disable_search: true" in path.read_text(encoding="utf-8"), (
+            f"{path.name} leaves the uploader's search enabled, so a wrong `files:` path cannot fail the build"
+        )
 
 
 def test_the_scan_can_fail(tmp_path):


### PR DESCRIPTION
> **Held for review — do not merge.** Opened ready-for-review so the full CI matrix runs; the merge decision is the maintainer's.

Template update **v0.41.2 → v0.41.4**. Four files, no conflicts, no `.rej`.

> **v0.41.3 is skipped deliberately.** It is tagged and released but withdrawn: it moved a block inside the generated `tests/conftest.py`, which makes `copier update` reject the whole file and revert it to the template stub. This repo is where that was measured — 184 lines to 41, with `_isolated_cwd`, `run_checks` and `daily_y_X_factory` surviving only in a `.rej`. v0.41.4 reverts it, and this update was pinned with `--vcs-ref v0.41.4`. **`tests/conftest.py` is unchanged here: still 184 lines, not in this diff.**

## What actually changes

**The nightly Codecov upload can no longer pass on the wrong file.** `nightly.yml`'s Codecov step had neither a `files:` input nor `disable_search:`, so it uploaded whatever the uploader's fallback search happened to find and reported success regardless. It now names `.artifacts/coverage.xml` explicitly, with `disable_search: true` and `fail_ci_if_error: true` — the same shape `tests.yml` already had.

**The check that should have caught it no longer names its own scope.** `tests/test_artifact_paths.py` read `.github/workflows/tests.yml` by name, so it was structurally unable to see the second upload — which is why the gap survived the release that removed exactly this pattern from `tests.yml`. It now **discovers** every workflow containing a Codecov step and asserts over all of them, plus a new `test_a_coverage_upload_exists_to_check` guard that fails if that set is ever empty.

**`.gitignore`** — comment only, recording the measured Hypothesis self-ignore range. The `.hypothesis/` entry itself is unchanged.

## Verification

| check | result |
|---|---|
| `.rej` files | none |
| conflict markers (`^(<<<<<<<\|>>>>>>>\|=======)( \|$)`) | none |
| `git status` `U` states | none |
| **`tests/conftest.py`** | **184 lines, byte-identical to `main` — not in the diff** |
| `tests/test_artifact_paths.py` | **7 passed** (6 before + the new guard) |
| workflows discovered by the new check | **2 — `nightly.yml`, `tests.yml`** |
| falsification: strip `nightly.yml`'s `files:`/`disable_search:` | both checks fail **naming `nightly.yml`** |
| falsification: remove every Codecov step | guard test fails |
| `git diff --stat -- docs/assets` | **empty** |
| nav, per section | Home 1, Tutorials 2, How-to 7, Examples 1, Explanation 3, Reference 3 — **17, unchanged** |
| `astral-sh/setup-uv` version pins | **13**, all `0.12.1` |
| digest-pinned `uses:` lines | **49**; tag-pinned: **0** |
| `prek run --all-files` | all hooks pass |

Both falsifications were run against a **scratch copy** of the tree, never the working files. Every touched file was diffed whole-file against its pre-update state.

## Note for reviewers

`Validate Commit Message` reports pass on a multi-commit PR while validating nothing (its steps are gated on `commits == 1`). This PR has one commit, so it does validate here — but do not read that check as evidence in general.
