### PR TITLE
ci(automerge): drain the dependency queue one PR at a time

### DIFF
--- a/.claude/skills/update-from-template/references/file-classification.md
+++ b/.claude/skills/update-from-template/references/file-classification.md
@@ -119,6 +119,12 @@ CITATION.cff                       # renders entirely from copier answers, which
                                    # `automerge` label, or the workflow starts approving
                                    # updates nothing chose to automate. A project may add
                                    # its own steps, so merge rather than overwrite.
+.github/workflows/drain-automerge-queue.yml  # conditional: include_actions. Advances one
+                                   # automerge PR per push to the default branch. The
+                                   # App-token step is load-bearing, not boilerplate: a
+                                   # branch updated with GITHUB_TOKEN triggers no checks,
+                                   # so the PR would stall with its required checks never
+                                   # reported. Do not "simplify" it to GITHUB_TOKEN.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: b6e06378b2e2967808bfb55f68f0affad0fcca28
+_commit: d1a6ab905ab9ff851af3db8faca1ec244275a09f
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/drain-automerge-queue.yml
+++ b/.github/workflows/drain-automerge-queue.yml
@@ -1,0 +1,99 @@
+name: Drain Automerge Queue
+
+# A branch protection rule that requires branches to be up to date deadlocks
+# unattended dependency updates. GitHub's auto-merge refuses to merge a PR whose
+# branch is behind its base, and it does NOT update the branch itself. Renovate does
+# rebase stale branches, but only when it next runs, and the moment one PR merges every
+# other open branch is behind again. The result is roughly one merge per run: the queue
+# never drains, while every PR in it looks approved, green and ready.
+#
+# This workflow closes that gap. On every push to the default branch it advances exactly
+# ONE pull request: the oldest automerge-labelled bot PR that is behind. Updating the
+# branch reruns its checks, auto-merge then lands it, and that merge pushes the default
+# branch again, which runs this workflow for the next one. The queue drains itself, one
+# CI run per merge, with no schedule and nothing to maintain.
+#
+# It does nothing at all when no PR is waiting, and it stops on its own once the queue is
+# empty, so there is no loop to break.
+
+on:
+  push:
+    branches: [main]
+
+# Least-privilege default. This job needs no GITHUB_TOKEN scopes at all, because every
+# API call is made with the App token minted below.
+permissions: {}
+
+# One at a time. Several merges landing together would otherwise each pick a PR, and a
+# burst of branch updates is the CI storm this design exists to avoid.
+concurrency:
+  group: drain-automerge-queue
+  cancel-in-progress: false
+
+jobs:
+  advance-one:
+    name: Advance the automerge queue
+    runs-on: ubuntu-latest
+    steps:
+      # The App token is not decoration. A branch updated with the default GITHUB_TOKEN
+      # does NOT trigger a new workflow run: GitHub suppresses that to prevent recursion.
+      # The updated head commit would therefore carry none of the required checks, they
+      # would sit "Expected -- waiting for status to be reported" forever, and auto-merge
+      # would never fire. The PR would look freshly updated and be more stuck than before.
+      # An App token is a different identity, so its push does trigger the checks.
+      - name: Generate a token from the fleet automation GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2.2.2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update the oldest automerge PR that is behind
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Oldest first, so the queue is FIFO and a PR cannot be starved by newer ones.
+          # The same three conditions as renovate-automerge.yml, for the same reasons:
+          # a Bot author, a `renovate/` branch, and the `automerge` label that the
+          # Renovate config applies only to rules it also marks `automerge: true`.
+          candidates=$(gh api \
+            "repos/$REPO/pulls?state=open&sort=created&direction=asc&per_page=100" \
+            --jq '.[]
+                  | select(.user.type == "Bot")
+                  | select(.head.ref | startswith("renovate/"))
+                  | select([.labels[].name] | index("automerge"))
+                  | .number')
+
+          if [ -z "$candidates" ]; then
+            echo "No automerge-labelled bot pull requests are open. Nothing to do."
+            exit 0
+          fi
+
+          for number in $candidates; do
+            # `mergeable_state` is computed lazily: the first read can legitimately
+            # return "unknown" and resolve on a retry. Treating that as "not behind"
+            # would skip a PR that is in fact waiting, so ask again before giving up.
+            state=""
+            for _ in 1 2 3; do
+              state=$(gh api "repos/$REPO/pulls/$number" --jq '.mergeable_state')
+              [ "$state" != "unknown" ] && break
+              sleep 5
+            done
+
+            echo "PR #${number}: mergeable_state=${state}"
+
+            if [ "$state" = "behind" ]; then
+              echo "Updating #${number} so its checks rerun against the current base."
+              gh api -X PUT "repos/$REPO/pulls/${number}/update-branch"
+              echo "Done. Auto-merge lands it once the required checks pass, and that"
+              echo "merge triggers this workflow again for the next one."
+              exit 0
+            fi
+          done
+
+          # Everything else is already current, or blocked on its own checks, or has a
+          # real conflict. None of those is something a branch update can fix.
+          echo "No automerge pull request is behind its base. Nothing to advance."


### PR DESCRIPTION
**Held for review, do not merge.**

Template update `v0.43.1` -> `v0.44.0` (`d1a6ab9`).

## What lands

A single new workflow, `.github/workflows/drain-automerge-queue.yml` (99 lines), plus its
tier entry in the `update-from-template` skill reference and the `_commit` bump.

The automerge chain shipped in v0.42.0 approves and enables auto-merge on dependency PRs,
and nothing merged. The org ruleset sets `strict_required_status_checks_policy: true`, and
GitHub's auto-merge refuses to merge a branch that is behind its base while declining to
update the branch itself. Approved, green PRs sit in `mergeable_state: behind` forever.

On every push to `main` this workflow advances exactly one pull request: the oldest
automerge-labelled bot PR that is behind. Updating its branch reruns its checks, auto-merge
lands it, and that merge pushes `main` again, which runs the workflow for the next one. One
CI run per merge, no schedule, and it exits quietly when the queue is empty.

The App-token step is load-bearing rather than boilerplate: a branch updated with
`GITHUB_TOKEN` triggers no workflow run, so the updated head would carry none of the
required checks and the PR would deadlock while looking freshly updated.

## What did not change, and why

v0.44.0 also reseeds `astral-sh/setup-uv`'s `version:` input from `0.10.0` to `0.12.3`
across `changelog.yml`, `commit-message.yml`, `nightly.yml`, `publish-release.yml` and
`tests.yml`, at 13 sites. Renovate had already moved this repo to `0.12.3`, so all five
files come out byte-identical to `main`. That is the correct outcome, not a skipped update.

## Verification

- `git diff --stat -- docs/assets` is **empty**. All 7 asset files hash-identical before and
  after; copier's output contained no `Bin` line.
- Digest-pinned `uses:` lines: **49 before, 49 after**.
- uv `version:` sites: **13 before, 13 after**, all `"0.12.3"`. No `"0.10.0"` residue.
- The local `exclude:` block in `tests.yml` (ray has no cp313 Windows wheel) is intact, as
  is the Renovate-bumped `GITLEAKS_VERSION=8.30.1`.
- No `.rej` files, no conflict markers, no `U` states.
- `mkdocs.yml` nav unchanged at 18 leaves; `renovate.json`, `tests/conftest.py`,
  `docs_build/*`, `pyproject.toml`, `noxfile.py`, `justfile`, `CONTRIBUTING.md` and every
  docs page untouched.
- The delivered workflow is byte-identical to a pristine `copier copy --vcs-ref v0.44.0` at
  this repo's answers.
- `APP_ID` and `APP_PRIVATE_KEY` resolve from org secrets, the `automerge` label exists, and
  the trigger branch `main` is this repo's default branch.

## Verification limits

`drain-automerge-queue.yml` triggers only on `push` to `main`, so nothing on this PR
exercises it. Its first real run will be this PR's own merge. It is verified statically
only, and it registers **no check at all** on this PR, since a workflow without a
`pull_request` trigger contributes nothing to the check list. `renovate-automerge.yml` does
appear, as `Approve and enable automerge  skipping`: that is its guard correctly declining a
human PR.

`Compat tests` also shows `skipping`; it is hardcoded `if: false` in this repo and was
before this PR.

CI: 23 checks registered, 21 green and 2 `skipping`. `Docs build (strict)` passed on a real
7.35s build reporting `No issues found`, 18 generated API pages and 5956 anchors, so it is
not a vacuous zero-warning pass. The RTD preview returns HTTP 200.
